### PR TITLE
Switch NODE_MODULE_VERSION to 48

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -49,6 +49,6 @@
  * an API is broken in the C++ side, including in v8 or
  * other dependencies.
  */
-#define NODE_MODULE_VERSION 49 /* Node.js v6.0.0 */
+#define NODE_MODULE_VERSION 48 /* Node.js v6.0.0 */
 
 #endif  // SRC_NODE_VERSION_H_


### PR DESCRIPTION
##### Checklist

- [ ] `make -j4 test` (UNIX), or `vcbuild test nosign` (Windows) passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Description of change

6.5.0 ships with V8 5.1 and _is_ ABI compatible with the rest of the 6.x series.

Clearly I need to hit up the checklist next to see how to ease the current Electron native pain.