### PR TITLE
Call process.log from fallback stream on Windows

### DIFF
--- a/lib/internal/process/stdio.js
+++ b/lib/internal/process/stdio.js
@@ -131,11 +131,16 @@ function setupStdio() {
   };
 }
 
-function createDevNull() {
+function createFallbackStream() {
   var Writable = process.NativeModule.require('stream').Writable;
   var stream = new Writable;
   stream.isTTY = false;
   stream._write = function(chunk, encoding, callback) {
+    if (process.platform === 'win32' &&
+        process.env.ELECTRON_RUN_AS_NODE &&
+        !process.env.ELECTRON_NO_ATTACH_CONSOLE) {
+      process.log(chunk.toString());
+    }
     process.nextTick(callback);
   };
   return stream;
@@ -179,7 +184,7 @@ function createWritableStdioStream(fd) {
   // Ignore stream errors.
   stream.on('error', function() {});
   } catch (error) {
-    stream = createDevNull();
+    stream = createFallbackStream();
   }
 
   // For supporting legacy API we put the FD here.


### PR DESCRIPTION
This is so logging still goes to the console on Windows when `ELECTRON_RUN_AS_NODE` is set and `ELECTRON_NO_ATTACH_CONSOLE` is not set.

Refs https://github.com/electron/electron/issues/5715
Refs https://github.com/electron/electron/pull/7578