### PR TITLE
Modify module wrapper so that "process", "global" are shadowable

### DIFF
--- a/lib/internal/bootstrap_node.js
+++ b/lib/internal/bootstrap_node.js
@@ -486,8 +486,9 @@
   };
 
   NativeModule.wrapper = [
-    '(function (exports, require, module, __filename, __dirname, process, global) { ',
-    '\n});'
+    '(function (exports, require, module, __filename, __dirname, process, global) { ' +
+    'return function (exports, require, module, __filename, __dirname) { ',
+    '\n}(exports, require, module, __filename, __dirname); });'
   ];
 
   NativeModule.prototype.compile = function() {


### PR DESCRIPTION
In upstream Node the module wrapper doesn't define "process" and "global" so you can write code like `const process = require('process')` without an error due to redefining the variable. Short of updating this entire vendored copy of Node, a simple way I could think of that provides similar semantics is to modify the module wrapper by adding an extra IIFE that omits "process" and "global" from its parameter list.

Test Plan: Tested this end-to-end inside of Electron itself by building it from source and ensuring the test app loads.