### PR TITLE
Fix node_platform for new v8

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -138,6 +138,10 @@ double NodePlatform::MonotonicallyIncreasingTime() {
   return uv_hrtime() / 1e9;
 }
 
+double NodePlatform::CurrentClockTimeMillis() {
+  return SystemClockTimeMillis();
+}
+
 TracingController* NodePlatform::GetTracingController() {
   return tracing_controller_.get();
 }

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -52,6 +52,7 @@ class NodePlatform : public v8::Platform {
                                      double delay_in_seconds) override;
   bool IdleTasksEnabled(v8::Isolate* isolate) override;
   double MonotonicallyIncreasingTime() override;
+  double CurrentClockTimeMillis() override;
   v8::TracingController* GetTracingController() override;
 
  private:


### PR DESCRIPTION
This fixes node_platform so that the upgrade-to-chromium-63 branch can actually get to some of the brightray stuff 👍 