### PR TITLE
Revert "Fix node_platform for new v8"

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -138,10 +138,6 @@ double NodePlatform::MonotonicallyIncreasingTime() {
   return uv_hrtime() / 1e9;
 }
 
-double NodePlatform::CurrentClockTimeMillis() {
-  return SystemClockTimeMillis();
-}
-
 TracingController* NodePlatform::GetTracingController() {
   return tracing_controller_.get();
 }

--- a/src/node_platform.h
+++ b/src/node_platform.h
@@ -52,7 +52,6 @@ class NodePlatform : public v8::Platform {
                                      double delay_in_seconds) override;
   bool IdleTasksEnabled(v8::Isolate* isolate) override;
   double MonotonicallyIncreasingTime() override;
-  double CurrentClockTimeMillis() override;
   v8::TracingController* GetTracingController() override;
 
  private:


### PR DESCRIPTION
Reverts electron/node#28

This change is not needed in the Node.js 8.9.3 branch, which is used for the Chromium **61**.
For Chromium **63** [`temporary-branch-for-chromium-63-upgrade`](https://github.com/electron/node/commits/temporary-branch-for-chromium-63-upgrade) is used (with Node.js 9.2.1).

cc @MarshallOfSound, @zcbenz 