### PR TITLE
Backport libuv/libuv#1419

### DIFF
--- a/deps/uv/src/win/fs.c
+++ b/deps/uv/src/win/fs.c
@@ -1118,8 +1118,6 @@ INLINE static int fs__stat_handle(HANDLE handle, uv_stat_t* statbuf) {
      */
     if (fs__readlink_handle(handle, NULL, &statbuf->st_size) == 0) {
       statbuf->st_mode |= S_IFLNK;
-    } else if (GetLastError() != ERROR_NOT_A_REPARSE_POINT) {
-      return -1;
     }
   }
 


### PR DESCRIPTION
```
win, fs: support unusual reparse points

Allow for running uv_fs_stat and uv_fs_lstat on all reparse points. One
of such points is new OneDrive drive with "files on demand" feature
enabled.
```

put https://github.com/electron/electron/pull/10377 to electeron-1-8-x
will fix https://github.com/electron/electron/issues/11570