### PR TITLE
Tweaks to ./configure to integrate with GN

### DIFF
--- a/configure
+++ b/configure
@@ -561,6 +561,7 @@ parser.add_option('--config-out-dir',
     dest='config_out_dir',
     help='output directory to write .gypi files to')
 
+# Electron-specific. When calling configure from the GN build, we will run gyp ourselves.
 parser.add_option('--no-run-gyp',
     action='store_false',
     dest='run_gyp',

--- a/configure
+++ b/configure
@@ -554,6 +554,18 @@ parser.add_option('-C',
     dest='compile_commands_json',
     help=optparse.SUPPRESS_HELP)
 
+# Electron-specific. Used to assist in calling the gyp build from GN.
+parser.add_option('--config-out-dir',
+    action='store',
+    default='.',
+    dest='config_out_dir',
+    help='output directory to write .gypi files to')
+
+parser.add_option('--no-run-gyp',
+    action='store_false',
+    dest='run_gyp',
+    help='suppress running gyp')
+
 (options, args) = parser.parse_args()
 
 # Expand ~ in the install prefix now, it gets written to multiple files.
@@ -1099,7 +1111,7 @@ def configure_static(o):
 
 
 def write(filename, data):
-  filename = filename
+  filename = os.path.join(options.config_out_dir, filename)
   print('creating %s' % filename)
   f = open(filename, 'w+')
   f.write(data)
@@ -1522,4 +1534,5 @@ gyp_args += args
 if warn.warned:
   warn('warnings were emitted in the configure phase')
 
-run_gyp(gyp_args)
+if options.run_gyp:
+  run_gyp(gyp_args)

--- a/node.gyp
+++ b/node.gyp
@@ -24,6 +24,7 @@
     'node_core_target_name%': 'node',
     'node_lib_target_name%': 'node_lib',
     'node_intermediate_lib_type%': 'static_library',
+    'config_gypi%': './config.gypi',
     'library_files': [
       'lib/internal/bootstrap_node.js',
       'lib/async_hooks.js',
@@ -712,7 +713,7 @@
           'process_outputs_as_sources': 1,
           'inputs': [
             '<@(library_files)',
-            './config.gypi',
+            '<(config_gypi)',
           ],
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',

--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -261,6 +261,13 @@ def JS2C(source, target):
     if '/' in name or '\\' in name:
       name = '/'.join(re.split('/|\\\\', name)[1:])
 
+    # Electron-specific: when driving the node build from Electron, we generate
+    # config.gypi in a separate directory and pass the absolute path to js2c.
+    # This overrides the absolute path so that the variable names in the
+    # generated C are as if it was in the root node directory.
+    if name.endswith("/config.gypi"):
+      name = "config.gypi"
+
     name = name.split('.', 1)[0]
     var = name.replace('-', '_').replace('/', '_')
     key = '%s_key' % var


### PR DESCRIPTION
GN doesn't like generated files being mixed in with source code, so this adds options to ./configure to allow the generated config.gypi file to be put elsewhere.