### PR TITLE
Workaround for boringssl/openssl incompatibility

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -6200,10 +6200,17 @@ void InitCryptoOnce() {
     ENGINE_load_builtin_engines();
 #endif
     ERR_clear_error();
+#ifdef OPENSSL_IS_BORINGSSL  // Once boringssl commit a02ed04d5 is in the past, we can remove this patch
+    CONF_modules_load_file(
+        nullptr,
+        nullptr,
+        CONF_MFLAGS_DEFAULT_SECTION);
+#else
     CONF_modules_load_file(
         openssl_config.c_str(),
         nullptr,
         CONF_MFLAGS_DEFAULT_SECTION);
+#endif
     int err = ERR_get_error();
     if (0 != err) {
       fprintf(stderr,


### PR DESCRIPTION
Small fix to get node building against BoringSSL. Once we upgrade boringssl past https://github.com/google/boringssl/commit/a02ed04d527e1b57b4efaa0b4f9bdbc1ed5975b2 (i.e. in chrome 66), this workaround will no longer be necessary.