### PR TITLE
chore: make --shared-[...]-path work on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -1039,8 +1039,14 @@ def configure_library(lib, output):
 
     # libpath needs to be provided ahead libraries
     if options.__dict__[shared_lib + '_libpath']:
-      output['libraries'] += [
-          '-L%s' % options.__dict__[shared_lib + '_libpath']]
+      if flavor == 'win':
+        if 'msvs_settings' not in output:
+          output['msvs_settings'] = { 'VCLinkerTool': { 'AdditionalOptions': [] } }
+        output['msvs_settings']['VCLinkerTool']['AdditionalOptions'] += [
+          '/LIBPATH:%s' % options.__dict__[shared_lib + '_libpath']]
+      else:
+        output['libraries'] += [
+            '-L%s' % options.__dict__[shared_lib + '_libpath']]
     elif pkg_libpath:
       output['libraries'] += [pkg_libpath]
 


### PR DESCRIPTION
The `-L<path>` syntax isn't recognized by link.exe, and gyp doesn't
translate it properly. Without this, link.exe generates the following
warning and fails to link:

```
LINK : warning LNK4044: unrecognized option '/LC:/Users/nornagon/...'; ignored
```

See nodejs/node#21530