### PR TITLE
Do not use external string as keys

### DIFF
--- a/tools/js2c.py
+++ b/tools/js2c.py
@@ -232,7 +232,10 @@ static struct : public v8::String::ExternalStringResource {{
 
 INITIALIZER = """\
 CHECK(target->Set(env->context(),
-                  {key}.ToStringChecked(env->isolate()),
+                  v8::String::NewFromUtf8(env->isolate(),
+                                          {key}.data(),
+                                          v8::NewStringType::kNormal,
+                                          arraysize(raw_{key})).ToLocalChecked(),
                   {value}.ToStringChecked(env->isolate())).FromJust());
 """
 


### PR DESCRIPTION
blink can not recognize external strings from Node, and it will crash when encountered one, for example executing `window.string_decoder`.

This will fix the first crash described in https://github.com/electron/electron/issues/12835#issuecomment-398941227.