### PR TITLE
fix: enable auto cert chaining to match OpenSSL behaviour

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -448,6 +448,8 @@ void SecureContext::Init(const FunctionCallbackInfo<Value>& args) {
   SSL_CTX_set_options(sc->ctx_.get(), SSL_OP_NO_SSLv2);
   SSL_CTX_set_options(sc->ctx_.get(), SSL_OP_NO_SSLv3);
 
+  SSL_CTX_clear_mode(sc->ctx_.get(), SSL_MODE_NO_AUTO_CHAIN);
+
   // SSL session cache configuration
   SSL_CTX_set_session_cache_mode(sc->ctx_.get(),
                                  SSL_SESS_CACHE_SERVER |


### PR DESCRIPTION
By default, OpenSSL will automatically build a certificate chain for a certificate based on trusted certs that are in the X509_STORE. BoringSSL disables this by default (see [#27](https://bugs.chromium.org/p/boringssl/issues/detail?id=27) and [#42](https://bugs.chromium.org/p/boringssl/issues/detail?id=42) on the BoringSSL bug tracker), but nodejs users will expect this behaviour (and indeed, one Electron test depends on it).