### PR TITLE
gn build files

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,11 +1,4 @@
 import("//electron/build/asar.gni")
-_protocol_generated = [
-  "node/inspector/protocol/Forward.h",
-  "node/inspector/protocol/Protocol.cpp",
-  "node/inspector/protocol/Protocol.h",
-  "node/inspector/protocol/NodeTracing.cpp",
-  "node/inspector/protocol/NodeTracing.h",
-]
 
 declare_args() {
   # Enable the V8 inspector protocol for use with node.
@@ -43,12 +36,6 @@ assert(!node_use_perfctr, "node_use_perfctr not supported in GN")
 
 assert(!node_enable_inspector || node_use_openssl,
        "node_enable_inspector requires node_use_openssl")
-
-group("electron_node") {
-  public_deps = [
-    ":node_lib",
-  ]
-}
 
 config("node_internals") {
   defines = [ "NODE_WANT_INTERNALS=1" ]
@@ -431,10 +418,6 @@ component("node_lib") {
 
   if (node_enable_inspector) {
     sources += [
-      "src/inspector/node_string.cc",
-      "src/inspector/node_string.h",
-      "src/inspector/tracing_agent.cc",
-      "src/inspector/tracing_agent.h",
       "src/inspector_agent.cc",
       "src/inspector_agent.h",
       "src/inspector_io.cc",
@@ -445,12 +428,9 @@ component("node_lib") {
       "src/inspector_socket_server.cc",
       "src/inspector_socket_server.h",
     ]
-    sources += rebase_path(_protocol_generated, ".", "$target_gen_dir/src")
     deps += [
-      ":protocol_generated_sources",
-      ":v8_inspector_compress_protocol_json",
+      "src/inspector",
     ]
-    include_dirs += [ "$target_gen_dir" ]
   }
 
   if (node_use_openssl) {
@@ -478,97 +458,6 @@ component("node_lib") {
   } else {
     defines += [ "NODE_USE_V8_PLATFORM=0" ]
   }
-}
-
-#### inspector_protocol
-
-template("generate_protocol_json") {
-  copy_target_name = target_name + "_copy"
-  copy(copy_target_name) {
-    sources = invoker.sources
-    outputs = [
-      "$target_gen_dir/{{source_file_part}}",
-    ]
-  }
-  copied_pdl = get_target_outputs(":$copy_target_name")
-  action(target_name) {
-    deps = [
-      ":$copy_target_name",
-    ]
-    sources = copied_pdl
-    outputs = invoker.outputs
-    script = "//v8/third_party/inspector_protocol/ConvertProtocolToJSON.py"
-    args = rebase_path(sources + outputs, root_build_dir)
-  }
-}
-
-import("//v8/gni/v8.gni")
-_inspector_protocol = v8_path_prefix + "/third_party/inspector_protocol"
-import("$_inspector_protocol/inspector_protocol.gni")
-
-generate_protocol_json("node_protocol_json") {
-  sources = [
-    "src/inspector/node_protocol.pdl",
-  ]
-  outputs = [
-    "$target_gen_dir/node_protocol.json",
-  ]
-}
-
-generate_protocol_json("v8_protocol_json") {
-  sources = [
-    "//v8/src/inspector/js_protocol.pdl",
-  ]
-  outputs = [
-    "$target_gen_dir/js_protocol.json",
-  ]
-}
-
-inspector_protocol_generate("protocol_generated_sources") {
-  # This is to ensure that the output directory exists--the code generator
-  # doesn't create it.
-  write_file("$target_gen_dir/src/node/inspector/protocol/.dummy", "")
-  deps = [
-    ":node_protocol_json",
-  ]
-
-  inspector_protocol_dir = _inspector_protocol
-  out_dir = "$target_gen_dir/src"
-  config_file = "src/inspector/node_protocol_config.json"
-  inputs = [
-    "$target_gen_dir/node_protocol.json",
-  ]
-  outputs = _protocol_generated
-}
-
-action("concatenate_protocols") {
-  deps = [
-    ":node_protocol_json",
-    ":v8_protocol_json",
-  ]
-  inputs = [
-    "$target_gen_dir/js_protocol.json",
-    "$target_gen_dir/node_protocol.json",
-  ]
-  outputs = [
-    "$target_gen_dir/concatenated_protocol.json",
-  ]
-  script = "//v8/third_party/inspector_protocol/ConcatenateProtocols.py"
-  args = rebase_path(inputs + outputs, root_build_dir)
-}
-
-action("v8_inspector_compress_protocol_json") {
-  deps = [
-    ":concatenate_protocols",
-  ]
-  inputs = [
-    "$target_gen_dir/concatenated_protocol.json",
-  ]
-  outputs = [
-    "$target_gen_dir/v8_inspector_protocol_json.h",
-  ]
-  script = "tools/compress_json.py"
-  args = rebase_path(inputs + outputs, root_build_dir)
 }
 
 ##### node_headers

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -272,13 +272,14 @@ config("node_lib_config") {
   }
 }
 
-static_library("node_lib") {
+component("node_lib") {
   deps = [
     ":node_js2c",
     "deps/cares",
     "deps/http_parser",
     "deps/nghttp2",
     "//third_party/zlib",
+    "//v8:v8_libplatform",
   ]
   public_deps = [
     "deps/uv",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -8,15 +8,38 @@ _protocol_generated = [
 ]
 
 declare_args() {
+  # Enable the V8 inspector protocol for use with node.
   node_enable_inspector = true
+
+  # Build node with SSL support.
+  # The variable is called "openssl" for parity with node's GYP build.
   node_use_openssl = true
+
+  # Use the specified path to system CA (PEM format) in addition to
+  # the BoringSSL supplied CA store or compiled-in Mozilla CA copy.
   node_openssl_system_ca_path = ""
+
+  # Initialize v8 platform during node.js startup.
+  # NB. this must be turned off in Electron, because Electron initializes the
+  # v8 platform itself.
   node_use_v8_platform = false
+
+  # Build with DTrace support.
   node_use_dtrace = false
+
+  # Build with ETW support.
   node_use_etw = false
+
+  # Build with performance counters.
   node_use_perfctr = false
+
+  # Build JavaScript in lib/ with DCHECK macros.
   node_debug_lib = false
 }
+
+assert(!node_use_dtrace, "node_use_dtrace not supported in GN")
+assert(!node_use_etw, "node_use_etw not supported in GN")
+assert(!node_use_perfctr, "node_use_perfctr not supported in GN")
 
 assert(!node_enable_inspector || node_use_openssl,
        "node_enable_inspector requires node_use_openssl")

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -205,12 +205,7 @@ chdir_action("node_js2c") {
     ":generate_config_gypi",
     ":node_js2c_inputs",
   ]
-  cwd = "$target_gen_dir/js2c_inputs"
-  sources = library_files + [ "$target_gen_dir/config.gypi" ]
-  outputs = [
-    "$target_gen_dir/node_javascript.cc",
-  ]
-  script = "tools/js2c.py"
+
   macro_inputs = []
   if (!node_use_dtrace && !node_use_etw) {
     macro_inputs += [ "src/notrace_macros.py" ]
@@ -223,9 +218,20 @@ chdir_action("node_js2c") {
   } else {
     macro_inputs += [ "tools/dcheck_macros.py" ]
   }
-  args = rebase_path(outputs) + library_files +
-         rebase_path([ "$target_gen_dir/config.gypi" ]) +
-         rebase_path(macro_inputs + [ "tools/check_macros.py" ])
+  macro_inputs += [ "tools/check_macros.py" ]
+
+  config_gypi = [ "$target_gen_dir/config.gypi" ]
+
+  inputs = library_files + macro_inputs + config_gypi
+  outputs = [
+    "$target_gen_dir/node_javascript.cc",
+  ]
+
+  cwd = "$target_gen_dir/js2c_inputs"
+  script = "tools/js2c.py"
+  args = rebase_path(outputs)
+  args += library_files
+  args += rebase_path(macro_inputs + config_gypi)
 }
 
 config("node_lib_config") {
@@ -415,7 +421,7 @@ static_library("node_lib") {
       "src/inspector_socket_server.cc",
       "src/inspector_socket_server.h",
     ]
-    sources += rebase_path(_protocol_generated, ".", target_gen_dir)
+    sources += rebase_path(_protocol_generated, ".", "$target_gen_dir/src")
     deps += [
       ":protocol_generated_sources",
       ":v8_inspector_compress_protocol_json",
@@ -450,70 +456,71 @@ static_library("node_lib") {
   }
 }
 
+#### inspector_protocol
+
+template("generate_protocol_json") {
+  copy_target_name = target_name + "_copy"
+  copy(copy_target_name) {
+    sources = invoker.sources
+    outputs = [
+      "$target_gen_dir/{{source_file_part}}",
+    ]
+  }
+  copied_pdl = get_target_outputs(":$copy_target_name")
+  action(target_name) {
+    deps = [
+      ":$copy_target_name",
+    ]
+    sources = copied_pdl
+    outputs = invoker.outputs
+    script = "//v8/third_party/inspector_protocol/ConvertProtocolToJSON.py"
+    args = rebase_path(sources + outputs, root_build_dir)
+  }
+}
+
 import("//v8/gni/v8.gni")
 _inspector_protocol = v8_path_prefix + "/third_party/inspector_protocol"
 import("$_inspector_protocol/inspector_protocol.gni")
 
-node_inspector_path = "src/inspector"
-
-action("prepare_protocol_json") {
+generate_protocol_json("node_protocol_json") {
   sources = [
-    "$node_inspector_path/node_protocol.pdl",
+    "src/inspector/node_protocol.pdl",
   ]
   outputs = [
     "$target_gen_dir/node_protocol.json",
   ]
-  script = "//v8/third_party/inspector_protocol/ConvertProtocolToJSON.py"
-  args = rebase_path(sources + outputs, root_build_dir)
 }
 
-inspector_protocol_generate("protocol_generated_sources") {
-  write_file("$target_gen_dir/node/inspector/protocol/.dummy", "")
-  deps = [
-    ":prepare_protocol_json",
-  ]
-  visibility = [ ":*" ]  # Only targets in this file can depend on this.
-
-  inspector_protocol_dir = _inspector_protocol
-  out_dir = target_gen_dir
-  config_file = "$node_inspector_path/node_protocol_config.json"
-  inputs = [
-    "$target_gen_dir/node_protocol.json",
-    "$node_inspector_path/node_protocol_config.json",
-  ]
-  outputs = _protocol_generated
-}
-
-import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
-executable("node") {
-  deps = [
-    ":node_lib",
-    "//build/config:exe_and_shlib_deps",
-    "//v8:v8_libplatform",
-  ]
+generate_protocol_json("v8_protocol_json") {
   sources = [
-    "src/node_main.cc",
-  ]
-  deps += [
-    #"//tools/v8_context_snapshot:v8_context_snapshot",
-  ]
-}
-
-action("v8_inspector_convert_protocol_to_json") {
-  inputs = [
     "//v8/src/inspector/js_protocol.pdl",
   ]
   outputs = [
     "$target_gen_dir/js_protocol.json",
   ]
-  script = "//v8/third_party/inspector_protocol/ConvertProtocolToJSON.py"
-  args = rebase_path(inputs + outputs)
+}
+
+inspector_protocol_generate("protocol_generated_sources") {
+  # This is to ensure that the output directory exists--the code generator
+  # doesn't create it.
+  write_file("$target_gen_dir/src/node/inspector/protocol/.dummy", "")
+  deps = [
+    ":node_protocol_json",
+  ]
+
+  inspector_protocol_dir = _inspector_protocol
+  out_dir = "$target_gen_dir/src"
+  config_file = "src/inspector/node_protocol_config.json"
+  inputs = [
+    "$target_gen_dir/node_protocol.json",
+  ]
+  outputs = _protocol_generated
 }
 
 action("concatenate_protocols") {
   deps = [
-    ":prepare_protocol_json",
-    ":v8_inspector_convert_protocol_to_json",
+    ":node_protocol_json",
+    ":v8_protocol_json",
   ]
   inputs = [
     "$target_gen_dir/js_protocol.json",
@@ -523,7 +530,7 @@ action("concatenate_protocols") {
     "$target_gen_dir/concatenated_protocol.json",
   ]
   script = "//v8/third_party/inspector_protocol/ConcatenateProtocols.py"
-  args = rebase_path(inputs + outputs)
+  args = rebase_path(inputs + outputs, root_build_dir)
 }
 
 action("v8_inspector_compress_protocol_json") {
@@ -537,8 +544,10 @@ action("v8_inspector_compress_protocol_json") {
     "$target_gen_dir/v8_inspector_protocol_json.h",
   ]
   script = "tools/compress_json.py"
-  args = rebase_path(inputs + outputs)
+  args = rebase_path(inputs + outputs, root_build_dir)
 }
+
+##### node_headers
 
 node_headers_dir = "$root_gen_dir/node_headers/include/node"
 

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,0 +1,532 @@
+import("//electron/build/asar.gni")
+_protocol_generated = [
+  "node/inspector/protocol/Forward.h",
+  "node/inspector/protocol/Protocol.cpp",
+  "node/inspector/protocol/Protocol.h",
+  "node/inspector/protocol/NodeTracing.cpp",
+  "node/inspector/protocol/NodeTracing.h",
+]
+
+declare_args() {
+  node_enable_inspector = true
+  node_use_openssl = true
+  node_openssl_system_ca_path = ""
+  node_use_v8_platform = false
+  node_use_dtrace = false
+  node_use_etw = false
+  node_use_perfctr = false
+  node_debug_lib = false
+}
+
+assert(!node_enable_inspector || node_use_openssl,
+       "node_enable_inspector requires node_use_openssl")
+
+group("electron_node") {
+  public_deps = [
+    ":node_lib",
+  ]
+}
+
+config("node_internals") {
+  defines = [ "NODE_WANT_INTERNALS=1" ]
+}
+
+library_files = [
+  "lib/internal/bootstrap/loaders.js",
+  "lib/internal/bootstrap/node.js",
+  "lib/async_hooks.js",
+  "lib/assert.js",
+  "lib/buffer.js",
+  "lib/child_process.js",
+  "lib/console.js",
+  "lib/constants.js",
+  "lib/crypto.js",
+  "lib/cluster.js",
+  "lib/dgram.js",
+  "lib/dns.js",
+  "lib/domain.js",
+  "lib/events.js",
+  "lib/fs.js",
+  "lib/http.js",
+  "lib/http2.js",
+  "lib/_http_agent.js",
+  "lib/_http_client.js",
+  "lib/_http_common.js",
+  "lib/_http_incoming.js",
+  "lib/_http_outgoing.js",
+  "lib/_http_server.js",
+  "lib/https.js",
+  "lib/inspector.js",
+  "lib/module.js",
+  "lib/net.js",
+  "lib/os.js",
+  "lib/path.js",
+  "lib/perf_hooks.js",
+  "lib/process.js",
+  "lib/punycode.js",
+  "lib/querystring.js",
+  "lib/readline.js",
+  "lib/repl.js",
+  "lib/stream.js",
+  "lib/_stream_readable.js",
+  "lib/_stream_writable.js",
+  "lib/_stream_duplex.js",
+  "lib/_stream_transform.js",
+  "lib/_stream_passthrough.js",
+  "lib/_stream_wrap.js",
+  "lib/string_decoder.js",
+  "lib/sys.js",
+  "lib/timers.js",
+  "lib/tls.js",
+  "lib/_tls_common.js",
+  "lib/_tls_wrap.js",
+  "lib/trace_events.js",
+  "lib/tty.js",
+  "lib/url.js",
+  "lib/util.js",
+  "lib/v8.js",
+  "lib/vm.js",
+  "lib/zlib.js",
+  "lib/internal/assert.js",
+  "lib/internal/async_hooks.js",
+  "lib/internal/buffer.js",
+  "lib/internal/cli_table.js",
+  "lib/internal/child_process.js",
+  "lib/internal/cluster/child.js",
+  "lib/internal/cluster/master.js",
+  "lib/internal/cluster/round_robin_handle.js",
+  "lib/internal/cluster/shared_handle.js",
+  "lib/internal/cluster/utils.js",
+  "lib/internal/cluster/worker.js",
+  "lib/internal/crypto/certificate.js",
+  "lib/internal/crypto/cipher.js",
+  "lib/internal/crypto/diffiehellman.js",
+  "lib/internal/crypto/hash.js",
+  "lib/internal/crypto/pbkdf2.js",
+  "lib/internal/crypto/random.js",
+  "lib/internal/crypto/sig.js",
+  "lib/internal/crypto/util.js",
+  "lib/internal/constants.js",
+  "lib/internal/encoding.js",
+  "lib/internal/errors.js",
+  "lib/internal/fixed_queue.js",
+  "lib/internal/freelist.js",
+  "lib/internal/fs/promises.js",
+  "lib/internal/fs/utils.js",
+  "lib/internal/http.js",
+  "lib/internal/inspector_async_hook.js",
+  "lib/internal/linkedlist.js",
+  "lib/internal/modules/cjs/helpers.js",
+  "lib/internal/modules/cjs/loader.js",
+  "lib/internal/modules/esm/loader.js",
+  "lib/internal/modules/esm/create_dynamic_module.js",
+  "lib/internal/modules/esm/default_resolve.js",
+  "lib/internal/modules/esm/module_job.js",
+  "lib/internal/modules/esm/module_map.js",
+  "lib/internal/modules/esm/translators.js",
+  "lib/internal/safe_globals.js",
+  "lib/internal/net.js",
+  "lib/internal/os.js",
+  "lib/internal/process/esm_loader.js",
+  "lib/internal/process/next_tick.js",
+  "lib/internal/process/promises.js",
+  "lib/internal/process/stdio.js",
+  "lib/internal/process/warning.js",
+  "lib/internal/process.js",
+  "lib/internal/querystring.js",
+  "lib/internal/process/write-coverage.js",
+  "lib/internal/readline.js",
+  "lib/internal/repl.js",
+  "lib/internal/repl/await.js",
+  "lib/internal/socket_list.js",
+  "lib/internal/test/binding.js",
+  "lib/internal/test/unicode.js",
+  "lib/internal/timers.js",
+  "lib/internal/tls.js",
+  "lib/internal/trace_events_async_hooks.js",
+  "lib/internal/tty.js",
+  "lib/internal/url.js",
+  "lib/internal/util.js",
+  "lib/internal/util/comparisons.js",
+  "lib/internal/util/inspector.js",
+  "lib/internal/util/types.js",
+  "lib/internal/http2/core.js",
+  "lib/internal/http2/compat.js",
+  "lib/internal/http2/util.js",
+  "lib/internal/v8_prof_polyfill.js",
+  "lib/internal/v8_prof_processor.js",
+  "lib/internal/stream_base_commons.js",
+  "lib/internal/vm/module.js",
+  "lib/internal/streams/lazy_transform.js",
+  "lib/internal/streams/async_iterator.js",
+  "lib/internal/streams/buffer_list.js",
+  "lib/internal/streams/duplexpair.js",
+  "lib/internal/streams/legacy.js",
+  "lib/internal/streams/destroy.js",
+  "lib/internal/streams/state.js",
+  "lib/internal/streams/pipeline.js",
+  "lib/internal/streams/end-of-stream.js",
+  "lib/internal/wrap_js_stream.js",
+  "deps/v8/tools/splaytree.js",
+  "deps/v8/tools/codemap.js",
+  "deps/v8/tools/consarray.js",
+  "deps/v8/tools/csvparser.js",
+  "deps/v8/tools/profile.js",
+  "deps/v8/tools/profile_view.js",
+  "deps/v8/tools/logreader.js",
+  "deps/v8/tools/arguments.js",
+  "deps/v8/tools/tickprocessor.js",
+  "deps/v8/tools/SourceMap.js",
+  "deps/v8/tools/tickprocessor-driver.js",
+  "deps/node-inspect/lib/_inspect.js",
+  "deps/node-inspect/lib/internal/inspect_client.js",
+  "deps/node-inspect/lib/internal/inspect_repl.js",
+  "deps/acorn/dist/acorn.js",
+  "deps/acorn/dist/walk.js",
+]
+
+copy("node_js2c_inputs") {
+  sources = library_files
+  outputs = [
+    "$target_gen_dir/js2c_inputs/{{source_target_relative}}",
+  ]
+}
+
+chdir_action("node_js2c") {
+  deps = [
+    ":node_js2c_inputs",
+  ]
+  cwd = "$target_gen_dir/js2c_inputs"
+  write_file("$target_gen_dir/js2c_inputs/config.gypi", [ "{'variables':{}}" ])
+  sources = library_files + [ "$target_gen_dir/js2c_inputs/config.gypi" ]
+  outputs = [
+    "$target_gen_dir/node_javascript.cc",
+  ]
+  script = "tools/js2c.py"
+  macro_inputs = []
+  if (!node_use_dtrace && !node_use_etw) {
+    macro_inputs += [ "src/notrace_macros.py" ]
+  }
+  if (!node_use_perfctr) {
+    macro_inputs += [ "src/noperfctr_macros.py" ]
+  }
+  if (node_debug_lib) {
+    macro_inputs += [ "tools/nodcheck_macros.py" ]
+  } else {
+    macro_inputs += [ "tools/dcheck_macros.py" ]
+  }
+  args = rebase_path(outputs) + library_files + [ "config.gypi" ] +
+         rebase_path(macro_inputs + [ "tools/check_macros.py" ])
+}
+
+config("node_lib_config") {
+  include_dirs = [ "src" ]
+  defines = []
+  if (node_enable_inspector) {
+    defines += [ "HAVE_INSPECTOR=1" ]
+  } else {
+    defines += [ "HAVE_INSPECTOR=0" ]
+  }
+  if (node_use_openssl) {
+    defines += [ "HAVE_OPENSSL=1" ]
+  } else {
+    defines += [ "HAVE_OPENSSL=0" ]
+  }
+}
+
+static_library("node_lib") {
+  deps = [
+    ":node_js2c",
+    "deps/cares",
+    "deps/http_parser",
+    "deps/nghttp2",
+    "//third_party/zlib",
+  ]
+  public_deps = [
+    "deps/uv",
+    "//v8",
+  ]
+  public_configs = [ ":node_lib_config" ]
+  include_dirs = [ "src" ]
+  cflags_cc = [
+    "-Wno-unused-variable",
+    "-Wno-deprecated-declarations",
+    "-Wno-implicit-fallthrough",
+    "-Wno-unused-private-field",
+  ]
+  defines = [
+    "NODE_ARCH=\"$target_cpu\"",
+    "NODE_PLATFORM=\"$target_os\"",
+    "NODE_WANT_INTERNALS=1",
+  ]
+  if (is_win) {
+    defines -= [ "NODE_PLATFORM=\"$target_os\"" ]
+    defines += [
+      "NODE_PLATFORM=\"win32\"",
+      "NOMINMAX",
+      "_UNICODE=1",
+    ]
+  } else {
+    defines += [ "__POSIX__" ]
+  }
+  sources = [
+    "$target_gen_dir/node_javascript.cc",
+    "src/aliased_buffer.h",
+    "src/async_wrap-inl.h",
+    "src/async_wrap.cc",
+    "src/async_wrap.h",
+    "src/base_object-inl.h",
+    "src/base_object.h",
+    "src/callback_scope.cc",
+    "src/callback_scope.h",
+    "src/cares_wrap.cc",
+    "src/connect_wrap.cc",
+    "src/connect_wrap.h",
+    "src/connection_wrap.cc",
+    "src/connection_wrap.h",
+    "src/env-inl.h",
+    "src/env.cc",
+    "src/env.h",
+    "src/exceptions.cc",
+    "src/exceptions.h",
+    "src/fs_event_wrap.cc",
+    "src/handle_wrap.cc",
+    "src/handle_wrap.h",
+    "src/js_stream.cc",
+    "src/js_stream.h",
+    "src/module_wrap.cc",
+    "src/module_wrap.h",
+    "src/node.cc",
+    "src/node.h",
+    "src/node_api.cc",
+    "src/node_api.h",
+    "src/node_api_types.h",
+    "src/node_buffer.cc",
+    "src/node_buffer.h",
+    "src/node_config.cc",
+    "src/node_constants.cc",
+    "src/node_constants.h",
+    "src/node_contextify.cc",
+    "src/node_contextify.h",
+    "src/node_debug_options.cc",
+    "src/node_debug_options.h",
+    "src/node_domain.cc",
+    "src/node_errors.h",
+    "src/node_file.cc",
+    "src/node_file.h",
+    "src/node_http2.cc",
+    "src/node_http2.h",
+    "src/node_http2_state.h",
+    "src/node_http_parser.cc",
+    "src/node_i18n.cc",
+    "src/node_i18n.h",
+    "src/node_internals.h",
+    "src/node_javascript.h",
+    "src/node_mutex.h",
+    "src/node_os.cc",
+    "src/node_perf.cc",
+    "src/node_perf.h",
+    "src/node_perf_common.h",
+    "src/node_persistent.h",
+    "src/node_platform.cc",
+    "src/node_platform.h",
+    "src/node_postmortem_metadata.cc",
+    "src/node_revert.h",
+    "src/node_root_certs.h",
+    "src/node_serdes.cc",
+    "src/node_stat_watcher.cc",
+    "src/node_trace_events.cc",
+    "src/node_types.cc",
+    "src/node_url.cc",
+    "src/node_util.cc",
+    "src/node_v8.cc",
+    "src/node_version.h",
+    "src/node_watchdog.cc",
+    "src/node_watchdog.h",
+    "src/node_wrap.h",
+    "src/node_zlib.cc",
+    "src/pipe_wrap.cc",
+    "src/pipe_wrap.h",
+    "src/process_wrap.cc",
+    "src/req_wrap-inl.h",
+    "src/req_wrap.h",
+    "src/signal_wrap.cc",
+    "src/spawn_sync.cc",
+    "src/stream_base-inl.h",
+    "src/stream_base.cc",
+    "src/stream_base.h",
+    "src/stream_pipe.cc",
+    "src/stream_pipe.h",
+    "src/stream_wrap.cc",
+    "src/stream_wrap.h",
+    "src/string_bytes.cc",
+    "src/string_bytes.h",
+    "src/string_decoder-inl.h",
+    "src/string_decoder.cc",
+    "src/string_decoder.h",
+    "src/tcp_wrap.cc",
+    "src/tcp_wrap.h",
+    "src/timer_wrap.cc",
+    "src/tracing/agent.cc",
+    "src/tracing/agent.h",
+    "src/tracing/node_trace_buffer.cc",
+    "src/tracing/node_trace_buffer.h",
+    "src/tracing/node_trace_writer.cc",
+    "src/tracing/node_trace_writer.h",
+    "src/tracing/trace_event.cc",
+    "src/tracing/trace_event.h",
+    "src/tty_wrap.cc",
+    "src/tty_wrap.h",
+    "src/udp_wrap.cc",
+    "src/udp_wrap.h",
+    "src/util-inl.h",
+    "src/util.cc",
+    "src/util.h",
+    "src/uv.cc",
+  ]
+  if (is_win) {
+    sources += [ "src/backtrace_win32.cc" ]
+  } else {
+    sources += [ "src/backtrace_posix.cc" ]
+  }
+
+  if (node_enable_inspector) {
+    sources += [
+      "src/inspector/node_string.cc",
+      "src/inspector/node_string.h",
+      "src/inspector/tracing_agent.cc",
+      "src/inspector/tracing_agent.h",
+      "src/inspector_agent.cc",
+      "src/inspector_agent.h",
+      "src/inspector_io.cc",
+      "src/inspector_io.h",
+      "src/inspector_js_api.cc",
+      "src/inspector_socket.cc",
+      "src/inspector_socket.h",
+      "src/inspector_socket_server.cc",
+      "src/inspector_socket_server.h",
+    ]
+    sources += rebase_path(_protocol_generated, ".", target_gen_dir)
+    deps += [
+      ":protocol_generated_sources",
+      ":v8_inspector_compress_protocol_json",
+    ]
+    include_dirs += [ "$target_gen_dir" ]
+  }
+
+  if (node_use_openssl) {
+    deps += [ "//third_party/boringssl" ]
+    sources += [
+      "src/node_crypto.cc",
+      "src/node_crypto.h",
+      "src/node_crypto_bio.cc",
+      "src/node_crypto_bio.h",
+      "src/node_crypto_clienthello.cc",
+      "src/node_crypto_clienthello.h",
+      "src/tls_wrap.cc",
+      "src/tls_wrap.h",
+    ]
+    defines += [
+      "NODE_OPENSSL_SYSTEM_CERT_PATH=\"$node_openssl_system_ca_path\"",
+      "EVP_CTRL_AEAD_SET_IVLEN=EVP_CTRL_GCM_SET_IVLEN",
+      "EVP_CTRL_CCM_SET_TAG=EVP_CTRL_GCM_SET_TAG",
+      "EVP_CTRL_AEAD_GET_TAG=EVP_CTRL_GCM_GET_TAG",
+    ]
+    cflags_cc += [ "-Wno-sign-compare" ]
+  }
+  if (node_use_v8_platform) {
+    defines += [ "NODE_USE_V8_PLATFORM=1" ]
+  } else {
+    defines += [ "NODE_USE_V8_PLATFORM=0" ]
+  }
+}
+
+import("//v8/gni/v8.gni")
+_inspector_protocol = v8_path_prefix + "/third_party/inspector_protocol"
+import("$_inspector_protocol/inspector_protocol.gni")
+
+node_inspector_path = "src/inspector"
+
+action("prepare_protocol_json") {
+  sources = [
+    "$node_inspector_path/node_protocol.pdl",
+  ]
+  outputs = [
+    "$target_gen_dir/node_protocol.json",
+  ]
+  script = "//v8/third_party/inspector_protocol/ConvertProtocolToJSON.py"
+  args = rebase_path(sources + outputs, root_build_dir)
+}
+
+inspector_protocol_generate("protocol_generated_sources") {
+  write_file("$target_gen_dir/node/inspector/protocol/.dummy", "")
+  deps = [
+    ":prepare_protocol_json",
+  ]
+  visibility = [ ":*" ]  # Only targets in this file can depend on this.
+
+  inspector_protocol_dir = _inspector_protocol
+  out_dir = target_gen_dir
+  config_file = "$node_inspector_path/node_protocol_config.json"
+  inputs = [
+    "$target_gen_dir/node_protocol.json",
+    "$node_inspector_path/node_protocol_config.json",
+  ]
+  outputs = _protocol_generated
+}
+
+import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
+executable("node") {
+  deps = [
+    ":node_lib",
+    "//build/config:exe_and_shlib_deps",
+    "//v8:v8_libplatform",
+  ]
+  sources = [
+    "src/node_main.cc",
+  ]
+  deps += [
+    #"//tools/v8_context_snapshot:v8_context_snapshot",
+  ]
+}
+
+action("v8_inspector_convert_protocol_to_json") {
+  inputs = [
+    "//v8/src/inspector/js_protocol.pdl",
+  ]
+  outputs = [
+    "$target_gen_dir/js_protocol.json",
+  ]
+  script = "//v8/third_party/inspector_protocol/ConvertProtocolToJSON.py"
+  args = rebase_path(inputs + outputs)
+}
+
+action("concatenate_protocols") {
+  deps = [
+    ":prepare_protocol_json",
+    ":v8_inspector_convert_protocol_to_json",
+  ]
+  inputs = [
+    "$target_gen_dir/js_protocol.json",
+    "$target_gen_dir/node_protocol.json",
+  ]
+  outputs = [
+    "$target_gen_dir/concatenated_protocol.json",
+  ]
+  script = "//v8/third_party/inspector_protocol/ConcatenateProtocols.py"
+  args = rebase_path(inputs + outputs)
+}
+
+action("v8_inspector_compress_protocol_json") {
+  deps = [
+    ":concatenate_protocols",
+  ]
+  inputs = [
+    "$target_gen_dir/concatenated_protocol.json",
+  ]
+  outputs = [
+    "$target_gen_dir/v8_inspector_protocol_json.h",
+  ]
+  script = "tools/compress_json.py"
+  args = rebase_path(inputs + outputs)
+}

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1,4 +1,5 @@
 import("//electron/build/asar.gni")
+import("//v8/gni/v8.gni")
 
 declare_args() {
   # Enable the V8 inspector protocol for use with node.
@@ -28,6 +29,10 @@ declare_args() {
 
   # Build JavaScript in lib/ with DCHECK macros.
   node_debug_lib = false
+
+  node_tag = ""
+  node_v8_options = ""
+  node_release_urlbase = ""
 }
 
 assert(!node_use_dtrace, "node_use_dtrace not supported in GN")
@@ -257,6 +262,11 @@ config("node_lib_config") {
   } else {
     defines += [ "HAVE_OPENSSL=0" ]
   }
+  if (v8_enable_i18n_support) {
+    defines += [ "NODE_HAVE_I18N_SUPPORT=1" ]
+  } else {
+    defines += [ "NODE_HAVE_I18N_SUPPORT=0" ]
+  }
 }
 
 component("node_lib") {
@@ -305,6 +315,20 @@ component("node_lib") {
     ]
   } else {
     defines += [ "__POSIX__" ]
+  }
+
+  if (node_tag != "") {
+    defines += [ "NODE_TAG=\"$node_tag\"" ]
+  }
+  if (node_v8_options != "") {
+    defines += [ "NODE_V8_OPTIONS=\"$node_v8_options\"" ]
+  }
+  if (node_release_urlbase != "") {
+    defines += [ "NODE_RELEASE_URLBASE=\"$node_release_urlbase\"" ]
+  }
+
+  if (v8_enable_i18n_support) {
+    deps += [ "//third_party/icu" ]
   }
 
   sources = [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -30,8 +30,15 @@ declare_args() {
   # Build JavaScript in lib/ with DCHECK macros.
   node_debug_lib = false
 
+  # Custom build tag.
   node_tag = ""
+
+  # V8 options to pass, see `node --v8-options` for examples
   node_v8_options = ""
+
+  # Provide a custom URL prefix for the `process.release` properties
+  # `sourceUrl` and `headersUrl`. When compiling a release build, this will
+  # default to https://nodejs.org/download/release/')
   node_release_urlbase = ""
 }
 
@@ -451,6 +458,10 @@ component("node_lib") {
     libs += [ "psapi.lib" ]
   } else {
     sources += [ "src/backtrace_posix.cc" ]
+  }
+
+  if (is_mac) {
+    libs += [ "CoreFoundation.framework" ]
   }
 
   if (node_enable_inspector) {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -280,21 +280,33 @@ component("node_lib") {
     "-Wno-implicit-fallthrough",
     "-Wno-unused-private-field",
   ]
-  defines = [
-    "NODE_ARCH=\"$target_cpu\"",
-    "NODE_PLATFORM=\"$target_os\"",
-    "NODE_WANT_INTERNALS=1",
-  ]
+  defines = [ "NODE_WANT_INTERNALS=1" ]
+
+  if (target_cpu == "x86") {
+    node_arch = "ia32"
+  } else {
+    node_arch = target_cpu
+  }
+  defines += [ "NODE_ARCH=\"$node_arch\"" ]
+
+  if (target_os == "win") {
+    node_platform = "win32"
+  } else if (target_os == "mac") {
+    node_platform = "darwin"
+  } else {
+    node_platform = target_os
+  }
+  defines += [ "NODE_PLATFORM=\"$node_platform\"" ]
+
   if (is_win) {
-    defines -= [ "NODE_PLATFORM=\"$target_os\"" ]
     defines += [
-      "NODE_PLATFORM=\"win32\"",
       "NOMINMAX",
       "_UNICODE=1",
     ]
   } else {
     defines += [ "__POSIX__" ]
   }
+
   sources = [
     "$target_gen_dir/node_javascript.cc",
     "src/aliased_buffer.h",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -424,6 +424,7 @@ component("node_lib") {
   ]
   if (is_win) {
     sources += [ "src/backtrace_win32.cc" ]
+    libs += [ "psapi.lib" ]
   } else {
     sources += [ "src/backtrace_posix.cc" ]
   }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -192,13 +192,21 @@ copy("node_js2c_inputs") {
   ]
 }
 
+action("generate_config_gypi") {
+  outputs = [
+    "$target_gen_dir/config.gypi",
+  ]
+  script = "tools/generate_config_gypi.py"
+  args = rebase_path(outputs, root_build_dir)
+}
+
 chdir_action("node_js2c") {
   deps = [
+    ":generate_config_gypi",
     ":node_js2c_inputs",
   ]
   cwd = "$target_gen_dir/js2c_inputs"
-  write_file("$target_gen_dir/js2c_inputs/config.gypi", [ "{'variables':{}}" ])
-  sources = library_files + [ "$target_gen_dir/js2c_inputs/config.gypi" ]
+  sources = library_files + [ "$target_gen_dir/config.gypi" ]
   outputs = [
     "$target_gen_dir/node_javascript.cc",
   ]
@@ -215,7 +223,8 @@ chdir_action("node_js2c") {
   } else {
     macro_inputs += [ "tools/dcheck_macros.py" ]
   }
-  args = rebase_path(outputs) + library_files + [ "config.gypi" ] +
+  args = rebase_path(outputs) + library_files +
+         rebase_path([ "$target_gen_dir/config.gypi" ]) +
          rebase_path(macro_inputs + [ "tools/check_macros.py" ])
 }
 
@@ -529,4 +538,103 @@ action("v8_inspector_compress_protocol_json") {
   ]
   script = "tools/compress_json.py"
   args = rebase_path(inputs + outputs)
+}
+
+node_headers_dir = "$root_gen_dir/node_headers/include/node"
+
+copy("node_headers") {
+  deps = [
+    ":generate_config_gypi",
+  ]
+  sources = [
+    "$target_gen_dir/config.gypi",
+    "common.gypi",
+    "src/callback_scope.h",
+    "src/core.h",
+    "src/exceptions.h",
+    "src/node.h",
+    "src/node_api.h",
+    "src/node_api_types.h",
+    "src/node_buffer.h",
+    "src/node_object_wrap.h",
+    "src/node_version.h",
+  ]
+  outputs = [
+    "$node_headers_dir/{{source_file_part}}",
+  ]
+}
+
+copy("v8_headers") {
+  sources = [
+    "//v8/include/v8-inspector-protocol.h",
+    "//v8/include/v8-inspector.h",
+    "//v8/include/v8-platform.h",
+    "//v8/include/v8-profiler.h",
+    "//v8/include/v8-testing.h",
+    "//v8/include/v8-util.h",
+    "//v8/include/v8-value-serializer-version.h",
+    "//v8/include/v8-version-string.h",
+    "//v8/include/v8-version.h",
+    "//v8/include/v8.h",
+    "//v8/include/v8config.h",
+  ]
+  outputs = [
+    "$node_headers_dir/{{source_file_part}}",
+  ]
+}
+
+copy("v8_platform_headers") {
+  sources = [
+    "//v8/include/libplatform/libplatform-export.h",
+    "//v8/include/libplatform/libplatform.h",
+    "//v8/include/libplatform/v8-tracing.h",
+  ]
+  outputs = [
+    "$node_headers_dir/libplatform/{{source_file_part}}",
+  ]
+}
+
+copy("uv_headers") {
+  sources = [
+    "deps/uv/include/android-ifaddrs.h",
+    "deps/uv/include/pthread-barrier.h",
+    "deps/uv/include/stdint-msvc2008.h",
+    "deps/uv/include/tree.h",
+    "deps/uv/include/uv-aix.h",
+    "deps/uv/include/uv-bsd.h",
+    "deps/uv/include/uv-darwin.h",
+    "deps/uv/include/uv-errno.h",
+    "deps/uv/include/uv-linux.h",
+    "deps/uv/include/uv-os390.h",
+    "deps/uv/include/uv-posix.h",
+    "deps/uv/include/uv-sunos.h",
+    "deps/uv/include/uv-threadpool.h",
+    "deps/uv/include/uv-unix.h",
+    "deps/uv/include/uv-version.h",
+    "deps/uv/include/uv-win.h",
+    "deps/uv/include/uv.h",
+  ]
+  outputs = [
+    "$node_headers_dir/{{source_file_part}}",
+  ]
+}
+
+copy("zlib_headers") {
+  sources = [
+    "//third_party/zlib/zconf.h",
+    "//third_party/zlib/zlib.h",
+  ]
+  outputs = [
+    "$node_headers_dir/{{source_file_part}}",
+  ]
+}
+
+group("headers") {
+  public_deps = [
+    ":node_headers",
+    ":uv_headers",
+    ":v8_headers",
+    ":v8_platform_headers",
+    ":zlib_headers",
+  ]
 }

--- a/deps/cares/BUILD.gn
+++ b/deps/cares/BUILD.gn
@@ -1,0 +1,119 @@
+config("cares_config") {
+  include_dirs = [ "include" ]
+}
+static_library("cares") {
+  defines = [ "CARES_STATICLIB" ]
+  include_dirs = [
+    "include",
+    "src",
+  ]
+  public_configs = [ ":cares_config" ]
+
+  sources = [
+    "include/ares.h",
+    "include/ares_rules.h",
+    "include/ares_version.h",
+    "include/nameser.h",
+    "src/ares__close_sockets.c",
+    "src/ares__get_hostent.c",
+    "src/ares__read_line.c",
+    "src/ares__timeval.c",
+    "src/ares_android.c",
+    "src/ares_cancel.c",
+    "src/ares_create_query.c",
+    "src/ares_data.c",
+    "src/ares_data.h",
+    "src/ares_destroy.c",
+    "src/ares_dns.h",
+    "src/ares_expand_name.c",
+    "src/ares_expand_string.c",
+    "src/ares_fds.c",
+    "src/ares_free_hostent.c",
+    "src/ares_free_string.c",
+    "src/ares_getenv.h",
+    "src/ares_gethostbyaddr.c",
+    "src/ares_gethostbyname.c",
+    "src/ares_getnameinfo.c",
+    "src/ares_getopt.c",
+    "src/ares_getopt.h",
+    "src/ares_getsock.c",
+    "src/ares_inet_net_pton.h",
+    "src/ares_init.c",
+    "src/ares_ipv6.h",
+    "src/ares_library_init.c",
+    "src/ares_library_init.h",
+    "src/ares_llist.c",
+    "src/ares_llist.h",
+    "src/ares_mkquery.c",
+    "src/ares_nowarn.c",
+    "src/ares_nowarn.h",
+    "src/ares_options.c",
+    "src/ares_parse_a_reply.c",
+    "src/ares_parse_aaaa_reply.c",
+    "src/ares_parse_mx_reply.c",
+    "src/ares_parse_naptr_reply.c",
+    "src/ares_parse_ns_reply.c",
+    "src/ares_parse_ptr_reply.c",
+    "src/ares_parse_soa_reply.c",
+    "src/ares_parse_srv_reply.c",
+    "src/ares_parse_txt_reply.c",
+    "src/ares_platform.h",
+    "src/ares_private.h",
+    "src/ares_process.c",
+    "src/ares_query.c",
+    "src/ares_search.c",
+    "src/ares_send.c",
+    "src/ares_setup.h",
+    "src/ares_strcasecmp.c",
+    "src/ares_strcasecmp.h",
+    "src/ares_strdup.c",
+    "src/ares_strdup.h",
+    "src/ares_strerror.c",
+    "src/ares_timeout.c",
+    "src/ares_version.c",
+    "src/ares_writev.c",
+    "src/ares_writev.h",
+    "src/bitncmp.c",
+    "src/bitncmp.h",
+    "src/inet_net_pton.c",
+    "src/inet_ntop.c",
+    "src/setup_once.h",
+  ]
+
+  if (!is_win) {
+    defines += [
+      "_DARWIN_USE_64_BIT_INODE=1",
+      "_LARGEFILE_SOURCE",
+      "_FILE_OFFSET_BITS=64",
+      "_GNU_SOURCE",
+    ]
+  }
+
+  if (is_win) {
+    defines += [ "CARES_PULL_WS2TCPIP_H=1" ]
+    include_dirs += [ "config/win32" ]
+    sources += [
+      "src/ares_getenv.c",
+      "src/ares_iphlpapi.h",
+      "src/ares_platform.c",
+      "src/config-win32.h",
+      "src/windows_port.c",
+    ]
+    libs += [
+      "ws2_32.lib",
+      "iphlpapi.lib",
+    ]
+  } else {
+    defines += [ "HAVE_CONFIG_H" ]
+  }
+
+  if (is_linux) {
+    include_dirs += [ "config/linux" ]
+    sources += [ "config/linux/ares_config.h" ]
+  }
+
+  if (is_mac) {
+    include_dirs += [ "config/darwin" ]
+    sources += [ "config/darwin/ares_config.h" ]
+  }
+}

--- a/deps/http_parser/BUILD.gn
+++ b/deps/http_parser/BUILD.gn
@@ -1,0 +1,13 @@
+config("http_parser_config") {
+  defines = [ "HTTP_PARSER_STRICT=0" ]
+  include_dirs = [ "." ]
+}
+
+static_library("http_parser") {
+  include_dirs = [ "." ]
+  public_configs = [ ":http_parser_config" ]
+  cflags_c = [ "-Wno-string-conversion" ]
+  sources = [
+    "http_parser.c",
+  ]
+}

--- a/deps/nghttp2/BUILD.gn
+++ b/deps/nghttp2/BUILD.gn
@@ -1,0 +1,43 @@
+config("nghttp2_config") {
+  defines = [ "NGHTTP2_STATICLIB" ]
+  include_dirs = [ "lib/includes" ]
+}
+static_library("nghttp2") {
+  public_configs = [ ":nghttp2_config" ]
+  defines = [
+    "_U_",
+    "BUILDING_NGHTTP2",
+    "NGHTTP2_STATICLIB",
+  ]
+  include_dirs = [ "lib/includes" ]
+  if (is_win) {
+    defines += [ "HAVE_CONFIG_H" ]
+  }
+
+  cflags_c = [ "-Wno-implicit-function-declaration" ]
+
+  sources = [
+    "lib/nghttp2_buf.c",
+    "lib/nghttp2_callbacks.c",
+    "lib/nghttp2_debug.c",
+    "lib/nghttp2_frame.c",
+    "lib/nghttp2_hd.c",
+    "lib/nghttp2_hd_huffman.c",
+    "lib/nghttp2_hd_huffman_data.c",
+    "lib/nghttp2_helper.c",
+    "lib/nghttp2_http.c",
+    "lib/nghttp2_map.c",
+    "lib/nghttp2_mem.c",
+    "lib/nghttp2_npn.c",
+    "lib/nghttp2_option.c",
+    "lib/nghttp2_outbound_item.c",
+    "lib/nghttp2_pq.c",
+    "lib/nghttp2_priority_spec.c",
+    "lib/nghttp2_queue.c",
+    "lib/nghttp2_rcbuf.c",
+    "lib/nghttp2_session.c",
+    "lib/nghttp2_stream.c",
+    "lib/nghttp2_submit.c",
+    "lib/nghttp2_version.c",
+  ]
+}

--- a/deps/uv/BUILD.gn
+++ b/deps/uv/BUILD.gn
@@ -1,0 +1,176 @@
+config("libuv_config") {
+  include_dirs = [ "include" ]
+
+  defines = []
+
+  if (is_linux) {
+    defines += [ "_POSIX_C_SOURCE=200112" ]
+  }
+  if (!is_win) {
+    defines += [
+      "_LARGEFILE_SOURCE",
+      "_FILE_OFFSET_BITS=64",
+    ]
+  }
+  if (is_mac) {
+    defines += [ "_DARWIN_USE_64_BIT_INODE=1" ]
+  }
+}
+
+static_library("uv") {
+  include_dirs = [
+    "include",
+    "src",
+  ]
+
+  public_configs = [ ":libuv_config" ]
+
+  ldflags = []
+
+  defines = []
+
+  cflags_c = [
+    "-Wno-implicit-function-declaration",
+    "-Wno-string-conversion",
+  ]
+
+  libs = []
+
+  sources = [
+    "include/tree.h",
+    "include/uv-errno.h",
+    "include/uv-threadpool.h",
+    "include/uv-version.h",
+    "include/uv.h",
+    "src/fs-poll.c",
+    "src/heap-inl.h",
+    "src/inet.c",
+    "src/queue.h",
+    "src/threadpool.c",
+    "src/uv-common.c",
+    "src/uv-common.h",
+    "src/uv-data-getter-setters.c",
+    "src/version.c",
+  ]
+
+  if (is_win) {
+    defines += [
+      "_WIN32_WINNT=0x0600",
+      "_GNU_SOURCE",
+    ]
+    sources += [
+      "include/uv-win.h",
+      "src/win/async.c",
+      "src/win/atomicops-inl.h",
+      "src/win/core.c",
+      "src/win/detect-wakeup.c",
+      "src/win/dl.c",
+      "src/win/error.c",
+      "src/win/fs-event.c",
+      "src/win/fs.c",
+      "src/win/getaddrinfo.c",
+      "src/win/getnameinfo.c",
+      "src/win/handle-inl.h",
+      "src/win/handle.c",
+      "src/win/internal.h",
+      "src/win/loop-watcher.c",
+      "src/win/pipe.c",
+      "src/win/poll.c",
+      "src/win/process-stdio.c",
+      "src/win/process.c",
+      "src/win/req-inl.h",
+      "src/win/req.c",
+      "src/win/signal.c",
+      "src/win/snprintf.c",
+      "src/win/stream-inl.h",
+      "src/win/stream.c",
+      "src/win/tcp.c",
+      "src/win/thread.c",
+      "src/win/timer.c",
+      "src/win/tty.c",
+      "src/win/udp.c",
+      "src/win/util.c",
+      "src/win/winapi.c",
+      "src/win/winapi.h",
+      "src/win/winsock.c",
+      "src/win/winsock.h",
+    ]
+    libs += [
+      "advapi32.lib",
+      "iphlpapi.lib",
+      "psapi.lib",
+      "shell32.lib",
+      "user32.lib",
+      "userenv.lib",
+      "ws2_32.lib",
+    ]
+  } else {
+    sources += [
+      "include/uv-aix.h",
+      "include/uv-bsd.h",
+      "include/uv-darwin.h",
+      "include/uv-linux.h",
+      "include/uv-sunos.h",
+      "include/uv-unix.h",
+      "src/unix/async.c",
+      "src/unix/atomic-ops.h",
+      "src/unix/core.c",
+      "src/unix/dl.c",
+      "src/unix/fs.c",
+      "src/unix/getaddrinfo.c",
+      "src/unix/getnameinfo.c",
+      "src/unix/internal.h",
+      "src/unix/loop-watcher.c",
+      "src/unix/loop.c",
+      "src/unix/pipe.c",
+      "src/unix/poll.c",
+      "src/unix/process.c",
+      "src/unix/signal.c",
+      "src/unix/spinlock.h",
+      "src/unix/stream.c",
+      "src/unix/tcp.c",
+      "src/unix/thread.c",
+      "src/unix/timer.c",
+      "src/unix/tty.c",
+      "src/unix/udp.c",
+    ]
+    libs += [ "m" ]
+    ldflags += [ "-pthread" ]
+  }
+  if (is_mac || is_linux) {
+    sources += [ "src/unix/proctitle.c" ]
+  }
+  if (is_mac) {
+    sources += [
+      "src/unix/darwin-proctitle.c",
+      "src/unix/darwin.c",
+      "src/unix/fsevents.c",
+    ]
+    defines += [
+      "_DARWIN_USE_64_BIT_INODE=1",
+      "_DARWIN_UNLIMITED_SELECT=1",
+    ]
+  }
+  if (is_linux) {
+    defines += [ "_GNU_SOURCE" ]
+    sources += [
+      "src/unix/linux-core.c",
+      "src/unix/linux-inotify.c",
+      "src/unix/linux-syscalls.c",
+      "src/unix/linux-syscalls.h",
+      "src/unix/procfs-exepath.c",
+      "src/unix/sysinfo-loadavg.c",
+      "src/unix/sysinfo-memory.c",
+    ]
+    libs += [
+      "dl",
+      "rt",
+    ]
+  }
+  if (is_mac) {  # is_bsd
+    sources += [
+      "src/unix/bsd-ifaddrs.c",
+      "src/unix/kqueue.c",
+    ]
+  }
+}

--- a/src/core.h
+++ b/src/core.h
@@ -8,7 +8,7 @@
 #   define NODE_EXTERN __declspec(dllimport)
 # endif
 #else
-# define NODE_EXTERN /* nothing */
+# define NODE_EXTERN __attribute__((visibility("default")))
 #endif
 
 #define NODE_MAKE_VERSION(major, minor, patch)                                \

--- a/src/inspector/BUILD.gn
+++ b/src/inspector/BUILD.gn
@@ -1,0 +1,148 @@
+import("//v8/gni/v8.gni")
+
+_inspector_protocol = v8_path_prefix + "/third_party/inspector_protocol"
+import("$_inspector_protocol/inspector_protocol.gni")
+
+_protocol_generated = [
+  "protocol/Forward.h",
+  "protocol/Protocol.cpp",
+  "protocol/Protocol.h",
+  "protocol/NodeTracing.cpp",
+  "protocol/NodeTracing.h",
+]
+
+# These are from node_protocol_config.json
+# These convoluted path hacks are to work around the fact that node.js is very
+# confused about what paths are in its includes, without changing node at all.
+# Hopefully, keying everything in this file off the paths that are in
+# node_protocol_config.json will mean that the paths stay in sync.
+inspector_protocol_package = "src/node/inspector/protocol"
+inspector_protocol_output = "node/inspector/protocol"
+
+config("inspector_config") {
+  include_dirs = [
+    "$target_gen_dir",
+    "$target_gen_dir/src",
+  ]
+}
+
+source_set("inspector") {
+  sources = [
+    "node_string.cc",
+    "node_string.h",
+    "tracing_agent.cc",
+    "tracing_agent.h",
+  ]
+  sources += rebase_path(_protocol_generated,
+                         ".",
+                         "$target_gen_dir/$inspector_protocol_package/..")
+  include_dirs = [
+    "//v8/include",
+    "..",
+  ]
+  deps = [
+    ":protocol_generated_sources",
+    ":v8_inspector_compress_protocol_json",
+    "../../deps/uv",
+    "//third_party/icu:icuuc",
+  ]
+  defines = [ "NODE_WANT_INTERNALS=1" ]
+  public_configs = [ ":inspector_config" ]
+}
+
+inspector_protocol_generate("protocol_generated_sources") {
+  # This is to ensure that the output directory exists--the code generator
+  # doesn't create it.
+  write_file("$target_gen_dir/$inspector_protocol_package/.dummy", "")
+  deps = [
+    ":node_protocol_json",
+    ":node_protocol_config",
+  ]
+
+  inspector_protocol_dir = _inspector_protocol
+  out_dir = "$target_gen_dir/src"
+  config_file = "$target_gen_dir/node_protocol_config.json"
+  inputs = [
+    "$target_gen_dir/node_protocol.json",
+  ]
+
+  outputs =
+      rebase_path(_protocol_generated, ".", "$inspector_protocol_output/..")
+}
+
+template("generate_protocol_json") {
+  copy_target_name = target_name + "_copy"
+  copy(copy_target_name) {
+    sources = invoker.sources
+    outputs = [
+      "$target_gen_dir/{{source_file_part}}",
+    ]
+  }
+  copied_pdl = get_target_outputs(":$copy_target_name")
+  action(target_name) {
+    deps = [
+      ":$copy_target_name",
+    ]
+    sources = copied_pdl
+    outputs = invoker.outputs
+    script = "//v8/third_party/inspector_protocol/ConvertProtocolToJSON.py"
+    args = rebase_path(sources + outputs, root_build_dir)
+  }
+}
+
+copy("node_protocol_config") {
+  sources = [
+    "node_protocol_config.json"
+  ]
+  outputs = [
+    "$target_gen_dir/{{source_file_part}}"
+  ]
+}
+
+generate_protocol_json("node_protocol_json") {
+  sources = [
+    "node_protocol.pdl",
+  ]
+  outputs = [
+    "$target_gen_dir/node_protocol.json",
+  ]
+}
+
+generate_protocol_json("v8_protocol_json") {
+  sources = [
+    "//v8/src/inspector/js_protocol.pdl",
+  ]
+  outputs = [
+    "$target_gen_dir/js_protocol.json",
+  ]
+}
+
+action("concatenate_protocols") {
+  deps = [
+    ":node_protocol_json",
+    ":v8_protocol_json",
+  ]
+  inputs = [
+    "$target_gen_dir/js_protocol.json",
+    "$target_gen_dir/node_protocol.json",
+  ]
+  outputs = [
+    "$target_gen_dir/concatenated_protocol.json",
+  ]
+  script = "//v8/third_party/inspector_protocol/ConcatenateProtocols.py"
+  args = rebase_path(inputs + outputs, root_build_dir)
+}
+
+action("v8_inspector_compress_protocol_json") {
+  deps = [
+    ":concatenate_protocols",
+  ]
+  inputs = [
+    "$target_gen_dir/concatenated_protocol.json",
+  ]
+  outputs = [
+    "$target_gen_dir/v8_inspector_protocol_json.h",
+  ]
+  script = "../../tools/compress_json.py"
+  args = rebase_path(inputs + outputs, root_build_dir)
+}

--- a/src/inspector/node_protocol_config.json
+++ b/src/inspector/node_protocol_config.json
@@ -1,7 +1,7 @@
 {
     "protocol": {
         "path": "node_protocol.json",
-        "package": "node/inspector/protocol",
+        "package": "src/node/inspector/protocol",
         "output": "node/inspector/protocol",
         "namespace": ["node", "inspector", "protocol"],
         "options": [

--- a/src/inspector/node_protocol_config.json
+++ b/src/inspector/node_protocol_config.json
@@ -1,7 +1,7 @@
 {
     "protocol": {
         "path": "node_protocol.json",
-        "package": "src/node/inspector/protocol",
+        "package": "node/inspector/protocol",
         "output": "node/inspector/protocol",
         "namespace": ["node", "inspector", "protocol"],
         "options": [

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -66,7 +66,7 @@ namespace node {
 inline v8::Local<v8::Value> ERR_BUFFER_TOO_LARGE(v8::Isolate *isolate) {
   char message[128];
   snprintf(message, sizeof(message),
-      "Cannot create a Buffer larger than 0x%lx bytes",
+      "Cannot create a Buffer larger than 0x%zx bytes",
       v8::TypedArray::kMaxLength);
   return ERR_BUFFER_TOO_LARGE(isolate, message);
 }

--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -1,0 +1,9 @@
+import sys
+
+def main(args):
+  out = args[0]
+  with open(out, 'w') as f:
+    f.write("{'variables':{}}\n")
+
+if __name__ == '__main__':
+  main(sys.argv[1:])

--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -1,3 +1,5 @@
+# TODO: assess which if any of the config variables are important to include in
+# the js2c'd config.gypi.
 import sys
 
 def main(args):


### PR DESCRIPTION
See electron/maintainers#217.

I think this might actually be similar or easier in terms of maintenance workload when compared to the approach of wrapping node's GYP build.

The list of JS files in lib/ can be deduplicated using gypi_to_gn.
