### PR TITLE
revert: "FIXME: Comment out TRACE_EVENT_METADATA1 call"

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -18,8 +18,8 @@ using v8::Task;
 using v8::TracingController;
 
 static void BackgroundRunner(void *data) {
-  // TRACE_EVENT_METADATA1("__metadata", "thread_name", "name",
-  //                       "BackgroundTaskRunner");
+  TRACE_EVENT_METADATA1("__metadata", "thread_name", "name",
+                        "BackgroundTaskRunner");
   TaskQueue<Task> *background_tasks = static_cast<TaskQueue<Task> *>(data);
   while (std::unique_ptr<Task> task = background_tasks->BlockingPop()) {
     task->Run();


### PR DESCRIPTION
This reverts commit 19d1193b83c65dff31f11fb4f825c1f64987c24f.

It is safe to merge it now, but the Node reference should be updated only after https://github.com/electron/electron/pull/14503 is backported to `3-0-x`.