### PR TITLE
fix: make common.gypi backwards-compatible with earlier nodes

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -48,6 +48,22 @@
     # Don't use ICU data file (icudtl.dat) from V8, we use our own.
     'icu_use_data_file_flag%': 0,
 
+    # When building native modules using 'npm install' with the system npm,
+    # node-gyp uses the `process.config` of the system npm to fill config.gypi.
+    # If the system npm is not as recent as Electron's node headers, which is
+    # likely, these variables will be missing from that config.gypi, and as a
+    # result, node-gyp will fail when building the native module with an error
+    # like:
+    #
+    #  gyp: name 'enable_lto' is not defined while evaluating condition
+    #  'enable_lto=="true"' in binding.gyp while trying to load binding.gyp
+    #
+    # We set default values here to avoid that error message, even though these
+    # aren't technically accurate, because most native modules don't depend on
+    # these values being accurate.
+    'build_v8_with_gn%': 'false',
+    'enable_lto%': 'false',
+
     'conditions': [
       ['GENERATOR=="ninja"', {
         'obj_dir': '<(PRODUCT_DIR)/obj',


### PR DESCRIPTION
When building native modules using 'npm install' with the system npm,
node-gyp uses the `process.config` of the system npm to fill config.gypi.
If the system npm is not as recent as Electron's node headers, which is
likely, these variables will be missing from that config.gypi, and as a
result, node-gyp will fail when building the native module with an error
like:

    gyp: name 'enable_lto' is not defined while evaluating condition
    'enable_lto=="true"' in binding.gyp while trying to load binding.gyp

We set default values here to avoid that error message, even though these
aren't technically accurate, because most native modules don't depend on
these values being accurate.
