### PR TITLE
fix: extern template classes shouldn't be dllexported

### DIFF
--- a/src/node_options.h
+++ b/src/node_options.h
@@ -340,7 +340,7 @@ class OptionsParser {
   friend void GetOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
-extern template class NODE_EXTERN OptionsParser<DebugOptions>;
+extern template class OptionsParser<DebugOptions>;
 
 class NODE_EXTERN DebugOptionsParser : public OptionsParser<DebugOptions> {
  public:


### PR DESCRIPTION
Fixes a build error on windows.