### PR TITLE
fix: export DebugOptions parser in a cross-platform-compatible way

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -324,6 +324,7 @@ component("node_lib") {
   defines = [
     "NODE_WANT_INTERNALS=1",
     "NODE_WITHOUT_NODE_OPTIONS",
+    "NODE_IMPLEMENTATION",
   ]
 
   if (is_component_build) {

--- a/src/node.h
+++ b/src/node.h
@@ -29,7 +29,11 @@
 #   define NODE_EXTERN __declspec(dllimport)
 # endif
 #else
+#if defined(NODE_IMPLEMENTATION)
 # define NODE_EXTERN __attribute__((visibility("default")))
+#else
+# define NODE_EXTERN
+#endif
 #endif
 
 #ifdef BUILDING_NODE_EXTENSION

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -22,7 +22,7 @@ namespace options_parser {
 // doc/api/cli.md
 // TODO(addaleax): Make that unnecessary.
 
-template class OptionsParser<DebugOptions>;
+template class EXPORT_TEMPLATE_DEFINE(NODE_EXTERN) OptionsParser<DebugOptions>;
 
 DebugOptionsParser::DebugOptionsParser() {
 #if HAVE_INSPECTOR

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <unordered_map>
 #include <memory>
+#include "base/export_template.h"
 #include "node_constants.h"
 
 namespace node {
@@ -340,7 +341,7 @@ class OptionsParser {
   friend void GetOptions(const v8::FunctionCallbackInfo<v8::Value>& args);
 };
 
-extern template class OptionsParser<DebugOptions>;
+extern template class EXPORT_TEMPLATE_DECLARE(NODE_EXTERN) OptionsParser<DebugOptions>;
 
 class NODE_EXTERN DebugOptionsParser : public OptionsParser<DebugOptions> {
  public:


### PR DESCRIPTION
On Windows, putting `__dllexport` on a template instantiation declaration causes a compile error, but on Mac/Linux, leaving off `__attribute__((visibility("default")))` causes a compile error. Turns out Chromium already has a tool for working around this and constructing the correct export syntax, so use that.