### PR TITLE
feat: add new built_with_electron variable to config.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -10,6 +10,7 @@
     'component%': 'static_library',   # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',   # we do enable multicore compiles, but not using the V8 way
     'python%': 'python',
+    'built_with_electron%': 1,
 
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,

--- a/common.gypi
+++ b/common.gypi
@@ -10,7 +10,6 @@
     'component%': 'static_library',   # NB. these names match with what V8 expects
     'msvs_multi_core_compile': '0',   # we do enable multicore compiles, but not using the V8 way
     'python%': 'python',
-    'built_with_electron%': 1,
 
     'node_shared%': 'false',
     'force_dynamic_crt%': 0,

--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -5,7 +5,7 @@ import sys
 def main(args):
   out = args[0]
   with open(out, 'w') as f:
-    f.write("{'variables':{}}\n")
+    f.write("{'variables':{'built_with_electron': 1}}\n")
 
 if __name__ == '__main__':
   main(sys.argv[1:])

--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -5,7 +5,7 @@ import sys
 def main(args):
   out = args[0]
   with open(out, 'w') as f:
-    f.write("{'variables':{'built_with_electron': 1}}\n")
+    f.write("{'variables':['built_with_electron': 1]}\n")
 
 if __name__ == '__main__':
   main(sys.argv[1:])


### PR DESCRIPTION
Resolves https://github.com/electron/electron/issues/6556.

Adds new `built_with_electron` variable to `config.gypi` generated by `tools/generate_config_gypi.py`

/cc @nornagon