### PR TITLE
fix: use zlib from electron_node

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -131,7 +131,7 @@ component("node_lib") {
     "deps/cares",
     "deps/http_parser",
     "deps/nghttp2",
-    "//third_party/zlib",
+    "deps/zlib",
     "//v8:v8_libplatform",
   ]
   public_deps = [
@@ -279,9 +279,8 @@ foreach(header_group, node_files.headers) {
 
 copy("zlib_headers") {
   sources = [
-    "//third_party/zlib/names.h",
-    "//third_party/zlib/zconf.h",
-    "//third_party/zlib/zlib.h",
+    "deps/zlib/zconf.h",
+    "deps/zlib/zlib.h",
   ]
   outputs = [
     "$node_headers_dir/include/node/{{source_file_part}}",

--- a/deps/zlib/BUILD.gn
+++ b/deps/zlib/BUILD.gn
@@ -1,0 +1,58 @@
+config("includes") {
+  include_dirs = [ "." ]
+}
+
+config("ignored_warnings") {
+  if (is_win) {
+    cflags = [
+      "/wd4131",  # old-style declarator
+      "/wd4127",  # conditional expression is constant
+      "/wd4244",  # possible loss of data on type conversion
+      "/wd4996",  # deprecated 'open'
+    ]
+  } else {
+    cflags = [
+      "-Wno-implicit-function-declaration",
+      "-Wno-shift-negative-value",
+    ]
+  }
+}
+
+source_set("zlib") {
+  sources = [
+    "adler32.c",
+    "compress.c",
+    "crc32.c",
+    "crc32.h",
+    "deflate.c",
+    "deflate.h",
+    "gzclose.c",
+    "gzguts.h",
+    "gzlib.c",
+    "gzread.c",
+    "gzwrite.c",
+    "infback.c",
+    "inffast.c",
+    "inffast.h",
+    "inffixed.h",
+    "inflate.c",
+    "inflate.h",
+    "inftrees.c",
+    "inftrees.h",
+    "trees.c",
+    "trees.h",
+    "uncompr.c",
+    "zconf.h",
+    "zlib.h",
+    "zutil.c",
+    "zutil.h",
+  ]
+
+  if (is_win) {
+    defines = [ "ZLIB_DLL" ]
+  }
+
+  configs += [ ":ignored_warnings" ]
+
+  public_configs = [ ":includes" ]
+}


### PR DESCRIPTION
Changing Chrome's zlib to export symbols caused issues in component builds (https://github.com/electron/electron/pull/15138) -- so I've taken a different approach:
- use node's zlib instead of chrome's
- let node's zlib export symbols

There are no conflicts because Chrome's zlib is already "namespaced" (i.e. `Cr_z_foo`). This also means we can actually generate a legitimate node-gyp import library (`electron.lib`) in debug builds by combining `node_lib.dll.lib` and `v8.dll.lib` using `lib.exe`.

This feels like the "right" solution, however, going the other direction (leaning into Chrome's zlib) would, I think, necessitate us switching zlib to be a formal component (and handling whatever non-trivial fallout that would have in the Chrome tree). 

Lastly, simply only exporting zlib symbols in non-component builds would "fix the problems" but leave us completely unable to compile native modules against a debug Electron's import library.