### PR TITLE
fix: remove NODE_WITHOUT_NODE_OPTIONS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -152,7 +152,6 @@ component("node_lib") {
   ]
   defines = [
     "NODE_WANT_INTERNALS=1",
-    "NODE_WITHOUT_NODE_OPTIONS",
     "NODE_IMPLEMENTATION",
   ]
 


### PR DESCRIPTION
Remove define precluding usage of `NODE_OPTIONS` in Electron in concert with https://github.com/electron/electron/pull/15158.

/cc @nornagon @deepak1556