### PR TITLE
fix: export napi symbols

### DIFF
--- a/src/node_api.h
+++ b/src/node_api.h
@@ -31,7 +31,7 @@ struct uv_loop_s;  // Forward declaration.
     #define NAPI_EXTERN __declspec(dllexport)
   #endif
 #else
-  #define NAPI_EXTERN /* nothing */
+  #define NAPI_EXTERN __attribute((visibility("default")))
 #endif
 
 #ifdef _WIN32

--- a/src/node_api.h
+++ b/src/node_api.h
@@ -31,7 +31,7 @@ struct uv_loop_s;  // Forward declaration.
     #define NAPI_EXTERN __declspec(dllexport)
   #endif
 #else
-  #define NAPI_EXTERN __attribute((visibility("default")))
+  #define NAPI_EXTERN __attribute__((visibility("default")))
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
matches the change in node.h in 88b494191c, both are necessary because Chromium builds with symbols hidden by default

Fixes electron/electron#15168