### PR TITLE
fix: have streams.js lazy-load original-fs, not fs

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -20,7 +20,7 @@ const util = require('util');
 let fs;
 function lazyFs() {
   if (fs === undefined)
-    fs = require('fs');
+    fs = require('original-fs');
   return fs;
 }
 


### PR DESCRIPTION
streams' lazy-loading was introduced in node to prevent a circular link between streams.js and fs.js, but this caused problems with Electron's fs wrapper.

Solution suggested by Benedek Heilig. Thanks @brenca!

Along with a node roll, this will fix https://github.com/electron/electron/issues/15543 for master

CC: @brenca, @MarshallOfSound 