### PR TITLE
chore: fix headers for M71

### DIFF
--- a/filenames.json
+++ b/filenames.json
@@ -16,6 +16,7 @@
     {
       "dest_dir": "include/node//",
       "files": [
+        "//v8/include/v8-internal.h",
         "//v8/include/v8-platform.h",
         "//v8/include/v8-profiler.h",
         "//v8/include/v8-testing.h",
@@ -137,7 +138,6 @@
     "lib/internal/crypto/cipher.js",
     "lib/internal/crypto/diffiehellman.js",
     "lib/internal/crypto/hash.js",
-    "lib/internal/crypto/keygen.js",
     "lib/internal/crypto/pbkdf2.js",
     "lib/internal/crypto/random.js",
     "lib/internal/crypto/scrypt.js",

--- a/tools/generate_gn_filenames_json.py
+++ b/tools/generate_gn_filenames_json.py
@@ -52,6 +52,10 @@ if __name__ == '__main__':
       files = [f for f in files if f.endswith('.h')]
     elif any(f.startswith('deps/v8/') for f in files):
       files = [f.replace('deps/v8/', '//v8/', 1) for f in files]
+
+      # For compatibility with V8 7.1
+      if not any('libplatform' in f for f in files):
+        files += ['//v8/include/v8-internal.h']
     hs = {'files': sorted(files), 'dest_dir': dest_dir}
     out['headers'].append(hs)
 


### PR DESCRIPTION
v8 7.1 split out v8-internal, but the hacky node header script i wrote gets its header list from node's v8, which is older.

https://chromium.googlesource.com/v8/v8/+/10afbb7e0f5934d872548c576f251a95f75e4d0e