### PR TITLE
fix: backport a node commit that cleans up GC listeners (5-0-x)

### DIFF
--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -296,6 +296,11 @@ inline void SetupGarbageCollectionTracking(Environment* env) {
                                         static_cast<void*>(env));
   env->isolate()->AddGCEpilogueCallback(MarkGarbageCollectionEnd,
                                         static_cast<void*>(env));
+  env->AddCleanupHook([](void* data) {
+    Environment* env = static_cast<Environment*>(data);
+    env->isolate()->RemoveGCPrologueCallback(MarkGarbageCollectionStart, data);
+    env->isolate()->RemoveGCEpilogueCallback(MarkGarbageCollectionEnd, data);
+  }, env);
 }
 
 // Gets the name of a function


### PR DESCRIPTION
Backports acc5a86efe241b52a2e0bf8c6b1ba886213cf9f0.