### PR TITLE
refactor: update patches to use process._linkedBinding

### DIFF
--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -662,7 +662,7 @@ function setupProcessICUVersions() {
 }
 
 function setupAsarSupport() {
-  process.binding('atom_common_asar').initAsarSupport(NativeModule._source, NativeModule.require);
+  process._linkedBinding('atom_common_asar').initAsarSupport(NativeModule._source, NativeModule.require);
 }
 
 function wrapForBreakOnFirstLine(source) {

--- a/src/node_binding.h
+++ b/src/node_binding.h
@@ -56,7 +56,7 @@ void GetInternalBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void GetLinkedBinding(const v8::FunctionCallbackInfo<v8::Value>& args);
 void DLOpen(const v8::FunctionCallbackInfo<v8::Value>& args);
 
-NODE_EXTERN node_module* get_builtin_module(const char *name);
+NODE_EXTERN node_module* get_linked_module(const char *name);
 
 }  // namespace binding
 


### PR DESCRIPTION
Updates existing patches that relied on legacy binding to use linked binding . No functionality change intended here.