### PR TITLE
fix: use `self` instead of `this` inside FSWatcher onchange callback

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1380,10 +1380,10 @@ function FSWatcher() {
     // after the handle is closed, and to fire both UV_RENAME and UV_CHANGE
     // if they are set by libuv at the same time.
     if (status < 0) {
-      if (this._handle !== null) {
+      if (self._handle !== null) {
         // We don't use this.close() here to avoid firing the close event.
-        this._handle.close();
-        this._handle = null;  // make the handle garbage collectable
+        self._handle.close();
+        self._handle = null;  // make the handle garbage collectable
       }
       const error = errors.uvException({
         errno: status,


### PR DESCRIPTION
To reproduce this behaviour on Electron `3.1.x`, I have a test project setup (on Windows, but I don't think that matters here):

```
$ git clone https://github.com/shiftkey/electron-quick-start -b repro-fswatcher-this-issue
$ npm install
$ npm start
```

Open the dev tools, click the `Click me!` button, see the app break into your code:

<img width="1320" alt="Screen Shot 2019-03-22 at 4 14 56 PM" src="https://user-images.githubusercontent.com/359239/54847646-aa3a7b00-4cbd-11e9-8b57-686af9d34f84.png">

Browse to the source of `fs.js` and put a break point inside `FSWatcher`'s ` `this._handle.onchange` callback (line 1382):

<img width="967" alt="Screen Shot 2019-03-22 at 4 15 33 PM" src="https://user-images.githubusercontent.com/359239/54847693-c6d6b300-4cbd-11e9-8f31-ac5edd1ff2e0.png">

Resume the app and it should hit the `fs.js` breakpoint. Check the local scope:

<img width="748" alt="Screen Shot 2019-03-22 at 4 16 50 PM" src="https://user-images.githubusercontent.com/359239/54847759-fab1d880-4cbd-11e9-919c-81d1b8879c0f.png">

Note that `this` inside the callback is the `FSEvent` associated with the `onchange` event, not the current `FSWatcher`. Further down the code uses `self.*` to emit events, and I think this was just a code path that rarely gets exercised.

I haven't triggered the specific code path because it requires the underlying filesystem to return a negative `status` value, but I know of these two issues in the wild that can be traced to this:

 - https://github.com/desktop/desktop/issues/7127
 - https://github.com/Microsoft/vscode/issues/70566

Let me know if this isn't the right branch to target for the PR, and if there's anything else I can do to expedite this fix into the main Electron repository.


