### PR TITLE
Fix crash when using https module 

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1628,6 +1628,25 @@ static void AddFingerprintDigest(const unsigned char* md,
   }
 }
 
+static MaybeLocal<Object> ECPointToBuffer(Environment* env,
+                                          const EC_GROUP* group,
+                                          const EC_POINT* point,
+                                          point_conversion_form_t form) {
+  size_t len = EC_POINT_point2oct(group, point, form, nullptr, 0, nullptr);
+  if (len == 0) {
+    env->ThrowError("Failed to get public key length");
+    return MaybeLocal<Object>();
+  }
+  MallocedBuffer<unsigned char> buf(
+      len, env->isolate()->GetArrayBufferAllocator());
+  len = EC_POINT_point2oct(group, point, form, buf.data, buf.size, nullptr);
+  if (len == 0) {
+    env->ThrowError("Failed to get public key");
+    return MaybeLocal<Object>();
+  }
+  return Buffer::New(env, buf.release(), len);
+}
+
 static Local<Object> X509ToObject(Environment* env, X509* cert) {
   EscapableHandleScope scope(env->isolate());
   Local<Context> context = env->context();
@@ -1744,16 +1763,12 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
       }
     }
 
-    unsigned char* pub = nullptr;
-    size_t publen = EC_KEY_key2buf(ec.get(), EC_KEY_get_conv_form(ec.get()),
-                                   &pub, nullptr);
-    if (publen > 0) {
-      Local<Object> buf = Buffer::New(env, pub, publen).ToLocalChecked();
-      // Ownership of pub pointer accepted by Buffer.
-      pub = nullptr;
+    const EC_POINT* pubkey = EC_KEY_get0_public_key(ec.get());
+    if (pubkey != nullptr) {
+      Local<Object> buf =
+          ECPointToBuffer(env, group, pubkey, EC_KEY_get_conv_form(ec.get()))
+              .ToLocalChecked();
       info->Set(context, env->pubkey_string(), buf).FromJust();
-    } else {
-      CHECK_NULL(pub);
     }
 
     const int nid = EC_GROUP_get_curve_name(group);
@@ -4548,28 +4563,14 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   if (pub == nullptr)
     return env->ThrowError("Failed to get ECDH public key");
 
-  int size;
   CHECK(args[0]->IsUint32());
   uint32_t val = args[0].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
-  size = EC_POINT_point2oct(ecdh->group_, pub, form, nullptr, 0, nullptr);
-  if (size == 0)
-    return env->ThrowError("Failed to get public key length");
-
-  auto* allocator = env->isolate()->GetArrayBufferAllocator();
-  unsigned char* out =
-      static_cast<unsigned char*>(allocator->AllocateUninitialized(size));
-
-  int r = EC_POINT_point2oct(ecdh->group_, pub, form, out, size, nullptr);
-  if (r != size) {
-    allocator->Free(out, size);
-    return env->ThrowError("Failed to get public key");
-  }
-
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), size).ToLocalChecked();
-  args.GetReturnValue().Set(buf);
+  MaybeLocal<Object> buf =
+      ECPointToBuffer(env, EC_KEY_get0_group(ecdh->key_.get()), pub, form);
+  if (buf.IsEmpty()) return;
+  args.GetReturnValue().Set(buf.ToLocalChecked());
 }
 
 
@@ -5177,25 +5178,9 @@ void ConvertKey(const FunctionCallbackInfo<Value>& args) {
   uint32_t val = args[2].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
-  int size = EC_POINT_point2oct(
-      group.get(), pub.get(), form, nullptr, 0, nullptr);
-
-  if (size == 0)
-    return env->ThrowError("Failed to get public key length");
-
-  auto* allocator = env->isolate()->GetArrayBufferAllocator();
-  unsigned char* out =
-      static_cast<unsigned char*>(allocator->AllocateUninitialized(size));
-
-  int r = EC_POINT_point2oct(group.get(), pub.get(), form, out, size, nullptr);
-  if (r != size) {
-    allocator->Free(out, size);
-    return env->ThrowError("Failed to get public key");
-  }
-
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), size).ToLocalChecked();
-  args.GetReturnValue().Set(buf);
+  MaybeLocal<Object> buf = ECPointToBuffer(env, group.get(), pub.get(), form);
+  if (buf.IsEmpty()) return;
+  args.GetReturnValue().Set(buf.ToLocalChecked());
 }
 
 


### PR DESCRIPTION
Backport a commit from upstream Node that fixes the crash when using https module, see https://github.com/electron/electron/issues/17309#issuecomment-477126169 for more details.

Note that I think the better solution is to rebase on the latest Node instead of cherry-picking the fix, as there are other critical crypto related fixes in upstream.

Another thing to note is that, currently the Node commit used by 5.0 is only referenced by a temporary branch, we would lose the history once the temporary branch is deleted. For the same reason I'm not sure how to backport this to 5.0, since the `electron-node-canary` branch is not used by 5.0.