### PR TITLE
Inherit ELECTRON_CRASHPAD_PIPE_NAME in child process

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -114,6 +114,10 @@ exports.fork = function fork(modulePath /* , args, options */) {
 
   options.env.ELECTRON_RUN_AS_NODE = 1;
 
+  if (process.platform === 'win32') {
+    options.env.ELECTRON_CRASHPAD_PIPE_NAME = process.env.ELECTRON_CRASHPAD_PIPE_NAME;
+  }
+
   if (!options.execPath && process.type && process.platform == 'darwin') {
     options.execPath = process.helperExecPath;
   }


### PR DESCRIPTION
With crashpad on Windows, the child processes have to communicate with the crash handler process via named pipe, and the name of pipe is passed via environment variables.

This patch ensures the `ELECTRON_CRASHPAD_PIPE_NAME` env is always inherited in child processes, so crashReporter can work correctly in node scripts.

Refs https://github.com/electron/electron/pull/18483.