### PR TITLE
chore: use boringssl key in process.versions instead of openssl

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -67,7 +67,7 @@ action("generate_config_gypi") {
     "$target_gen_dir/config.gypi",
   ]
   script = "tools/generate_config_gypi.py"
-  args = rebase_path(outputs, root_build_dir)
+  args = rebase_path(outputs, root_build_dir) + [ target_os ]
 }
 
 chdir_action("node_js2c") {

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -81,7 +81,7 @@ Metadata::Versions::Versions() {
     std::to_string(BrotliEncoderVersion() & 0xFFF);
 
 #if HAVE_OPENSSL
-  openssl = GetOpenSSLVersion();
+  boringssl = GetOpenSSLVersion();
 #endif
 
 #ifdef NODE_HAVE_I18N_SUPPORT

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -80,8 +80,10 @@ Metadata::Versions::Versions() {
     "." +
     std::to_string(BrotliEncoderVersion() & 0xFFF);
 
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && defined(OPENSSL_IS_BORINGSSL)
   boringssl = GetOpenSSLVersion();
+#elif HAVE_OPENSSL
+  openssl = GetOpenSSLVersion();
 #endif
 
 #ifdef NODE_HAVE_I18N_SUPPORT

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -33,8 +33,10 @@ namespace node {
   V(llhttp)                                                                    \
   V(http_parser)                                                               \
 
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && defined(OPENSSL_IS_BORINGSSL)
 #define NODE_VERSIONS_KEY_CRYPTO(V) V(boringssl)
+#elif HAVE_OPENSSL
+#define NODE_VERSIONS_KEY_CRYPTO(V) V(openssl)
 #else
 #define NODE_VERSIONS_KEY_CRYPTO(V)
 #endif

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -34,7 +34,7 @@ namespace node {
   V(http_parser)                                                               \
 
 #if HAVE_OPENSSL
-#define NODE_VERSIONS_KEY_CRYPTO(V) V(openssl)
+#define NODE_VERSIONS_KEY_CRYPTO(V) V(boringssl)
 #else
 #define NODE_VERSIONS_KEY_CRYPTO(V)
 #endif

--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -1,11 +1,18 @@
 # TODO: assess which if any of the config variables are important to include in
 # the js2c'd config.gypi.
 import sys
+import json
 
-def main(args):
-  out = args[0]
+def main(out, target_os):
+  config = {
+    'variables': {
+      'built_with_electron': 1,
+    }
+  }
+  if target_os == 'win':
+    config['variables']['node_with_ltcg'] = 'true'
   with open(out, 'w') as f:
-    f.write("{'variables':{'built_with_electron': 1}}\n")
+    json.dump(config, f, sort_keys=True)
 
 if __name__ == '__main__':
-  main(sys.argv[1:])
+  main(*sys.argv[1:])


### PR DESCRIPTION
In my opinion here is a better place to fix [this issue](https://github.com/electron/electron/issues/18826) as well as [this one](https://github.com/electron/electron/issues/18827). Basically, this replaces the `process.versions` dict key `openssl` with `boringssl`.

I think the code for getting the version is just fine, since `OPENSSL_VERSION_TEXT` resolves to `OpenSSL 1.1.0 (compatible; BoringSSL)`.

cc @codebytere @erickzhao 