### PR TITLE
chore: update location of js_protocol.pdl

### DIFF
--- a/src/inspector/BUILD.gn
+++ b/src/inspector/BUILD.gn
@@ -156,7 +156,7 @@ generate_protocol_json("node_protocol_json") {
 
 generate_protocol_json("v8_protocol_json") {
   sources = [
-    "//v8/include/js_protocol.pdl",
+    v8_inspector_js_protocol,
   ]
   outputs = [
     "$target_gen_dir/js_protocol.json",

--- a/src/inspector/BUILD.gn
+++ b/src/inspector/BUILD.gn
@@ -156,7 +156,7 @@ generate_protocol_json("node_protocol_json") {
 
 generate_protocol_json("v8_protocol_json") {
   sources = [
-    "//v8/src/inspector/js_protocol.pdl",
+    "//v8/include/js_protocol.pdl",
   ]
   outputs = [
     "$target_gen_dir/js_protocol.json",


### PR DESCRIPTION
Chromium changed the location of js_protocol.pdl:
https://chromium-review.googlesource.com/c/chromium/src/+/1665929

This PR updates to the new location.