### PR TITLE
fix: don't define BUILDING_V8_SHARED in component builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -153,9 +153,6 @@ config("node_internal_config") {
   }
   if (is_component_build) {
     defines += [
-      "BUILDING_V8_SHARED",
-      "BUILDING_V8_PLATFORM_SHARED",
-      "BUILDING_V8_BASE_SHARED",
       "NODE_SHARED_MODE",
     ]
   }


### PR DESCRIPTION
hopefully this'll fix the error we've been seeing:

```
../../v8/include/v8config.h:357:2: error: Inconsistent build configuration: To build the V8 shared library set BUILDING_V8_SHARED, to include its headers for linking against the V8 shared library set USING_V8_SHARED.
```