### PR TITLE
fix: remove array buffer allocator patch (electron-4.x)

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -613,6 +613,19 @@ An attempt was made to register something that is not a function as an
 The type of an asynchronous resource was invalid. Note that users are also able
 to define their own types if using the public embedder API.
 
+<a id="ERR_BUFFER_CONTEXT_NOT_AVAILABLE"></a>
+### ERR_BUFFER_CONTEXT_NOT_AVAILABLE
+
+An attempt was made to create a Node.js `Buffer` instance from addon or embedder
+code, while in a JS engine Context that is not associated with a Node.js
+instance. The data passed to the `Buffer` method will have been released
+by the time the method returns.
+
+When encountering this error, a possible alternative to creating a `Buffer`
+instance is to create a normal `Uint8Array`, which only differs in the
+prototype of the resulting object. `Uint8Array`s are generally accepted in all
+Node.js core APIs where `Buffer`s are; they are available in all Contexts.
+
 <a id="ERR_BUFFER_OUT_OF_BOUNDS"></a>
 ### ERR_BUFFER_OUT_OF_BOUNDS
 

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -47,8 +47,16 @@ inline uv_loop_t* IsolateData::event_loop() const {
   return event_loop_;
 }
 
-inline uint32_t* IsolateData::zero_fill_field() const {
-  return zero_fill_field_;
+inline bool IsolateData::uses_node_allocator() const {
+  return uses_node_allocator_;
+}
+
+inline v8::ArrayBuffer::Allocator* IsolateData::allocator() const {
+  return allocator_;
+}
+
+inline ArrayBufferAllocator* IsolateData::node_allocator() const {
+  return node_allocator_;
 }
 
 inline MultiIsolatePlatform* IsolateData::platform() const {

--- a/src/env-inl.h
+++ b/src/env-inl.h
@@ -669,6 +669,104 @@ inline IsolateData* Environment::isolate_data() const {
   return isolate_data_;
 }
 
+inline char* Environment::AllocateUnchecked(size_t size) {
+  return static_cast<char*>(
+      isolate_data()->allocator()->AllocateUninitialized(size));
+}
+
+inline char* Environment::Allocate(size_t size) {
+  char* ret = AllocateUnchecked(size);
+  CHECK_NE(ret, nullptr);
+  return ret;
+}
+
+inline void Environment::Free(char* data, size_t size) {
+  if (data != nullptr)
+    isolate_data()->allocator()->Free(data, size);
+}
+
+inline AllocatedBuffer Environment::AllocateManaged(size_t size, bool checked) {
+  char* data = checked ? Allocate(size) : AllocateUnchecked(size);
+  if (data == nullptr) size = 0;
+  return AllocatedBuffer(this, uv_buf_init(data, size));
+}
+
+inline AllocatedBuffer::AllocatedBuffer(Environment* env, uv_buf_t buf)
+    : env_(env), buffer_(buf) {}
+
+inline void AllocatedBuffer::Resize(size_t len) {
+  char* new_data = env_->Reallocate(buffer_.base, buffer_.len, len);
+  CHECK_IMPLIES(len > 0, new_data != nullptr);
+  buffer_ = uv_buf_init(new_data, len);
+}
+
+inline uv_buf_t AllocatedBuffer::release() {
+  uv_buf_t ret = buffer_;
+  buffer_ = uv_buf_init(nullptr, 0);
+  return ret;
+}
+
+inline char* AllocatedBuffer::data() {
+  return buffer_.base;
+}
+
+inline const char* AllocatedBuffer::data() const {
+  return buffer_.base;
+}
+
+inline size_t AllocatedBuffer::size() const {
+  return buffer_.len;
+}
+
+inline AllocatedBuffer::AllocatedBuffer(Environment* env)
+    : env_(env), buffer_(uv_buf_init(nullptr, 0)) {}
+
+inline AllocatedBuffer::AllocatedBuffer(AllocatedBuffer&& other)
+    : AllocatedBuffer() {
+  *this = std::move(other);
+}
+
+inline AllocatedBuffer& AllocatedBuffer::operator=(AllocatedBuffer&& other) {
+  clear();
+  env_ = other.env_;
+  buffer_ = other.release();
+  return *this;
+}
+
+inline AllocatedBuffer::~AllocatedBuffer() {
+  clear();
+}
+
+inline void AllocatedBuffer::clear() {
+  uv_buf_t buf = release();
+  env_->Free(buf.base, buf.len);
+}
+
+// It's a bit awkward to define this Buffer::New() overload here, but it
+// avoids a circular dependency with node_internals.h.
+namespace Buffer {
+v8::MaybeLocal<v8::Object> New(Environment* env,
+                               char* data,
+                               size_t length,
+                               bool uses_malloc);
+}
+
+inline v8::MaybeLocal<v8::Object> AllocatedBuffer::ToBuffer() {
+  CHECK_NOT_NULL(env_);
+  v8::MaybeLocal<v8::Object> obj = Buffer::New(env_, data(), size(), false);
+  if (!obj.IsEmpty()) release();
+  return obj;
+}
+
+inline v8::Local<v8::ArrayBuffer> AllocatedBuffer::ToArrayBuffer() {
+  CHECK_NOT_NULL(env_);
+  uv_buf_t buf = release();
+  return v8::ArrayBuffer::New(env_->isolate(),
+                              buf.base,
+                              buf.len,
+                              v8::ArrayBufferCreationMode::kInternalized);
+}
+
 inline void Environment::ThrowError(const char* errmsg) {
   ThrowError(v8::Exception::Error, errmsg);
 }

--- a/src/env.cc
+++ b/src/env.cc
@@ -13,6 +13,7 @@
 
 namespace node {
 
+using v8::ArrayBuffer;
 using v8::Context;
 using v8::FunctionTemplate;
 using v8::HandleScope;
@@ -691,6 +692,23 @@ void Environment::BuildEmbedderGraph(v8::Isolate* isolate,
   });
 }
 
+char* Environment::Reallocate(char* data, size_t old_size, size_t size) {
+  // If we know that the allocator is our ArrayBufferAllocator, we can let
+  // if reallocate directly.
+  if (isolate_data()->uses_node_allocator()) {
+    return static_cast<char*>(
+        isolate_data()->node_allocator()->Reallocate(data, old_size, size));
+  }
+  // Generic allocators do not provide a reallocation method; we need to
+  // allocate a new chunk of memory and copy the data over.
+  char* new_data = AllocateUnchecked(size);
+  if (new_data == nullptr) return nullptr;
+  memcpy(new_data, data, std::min(size, old_size));
+  if (size > old_size)
+    memset(new_data + old_size, 0, size - old_size);
+  Free(data, old_size);
+  return new_data;
+}
 
 // Not really any better place than env.cc at this moment.
 void BaseObject::DeleteMe(void* data) {

--- a/src/env.cc
+++ b/src/env.cc
@@ -36,11 +36,14 @@ void* Environment::kNodeContextTagPtr = const_cast<void*>(
 IsolateData::IsolateData(Isolate* isolate,
                          uv_loop_t* event_loop,
                          MultiIsolatePlatform* platform,
-                         uint32_t* zero_fill_field) :
-    isolate_(isolate),
-    event_loop_(event_loop),
-    zero_fill_field_(zero_fill_field),
-    platform_(platform) {
+                         ArrayBufferAllocator* node_allocator)
+    : isolate_(isolate),
+      event_loop_(event_loop),
+      allocator_(isolate->GetArrayBufferAllocator()),
+      node_allocator_(node_allocator),
+      uses_node_allocator_(allocator_ == node_allocator_),
+      platform_(platform) {
+  CHECK_NOT_NULL(allocator_);
   if (platform_ != nullptr)
     platform_->RegisterIsolate(isolate_, event_loop);
 

--- a/src/env.h
+++ b/src/env.h
@@ -362,14 +362,18 @@ class Environment;
 
 class IsolateData {
  public:
-  IsolateData(v8::Isolate* isolate, uv_loop_t* event_loop,
+  IsolateData(v8::Isolate* isolate,
+              uv_loop_t* event_loop,
               MultiIsolatePlatform* platform = nullptr,
-              uint32_t* zero_fill_field = nullptr);
+              ArrayBufferAllocator* node_allocator = nullptr);
   ~IsolateData();
   inline uv_loop_t* event_loop() const;
-  inline uint32_t* zero_fill_field() const;
   inline MultiIsolatePlatform* platform() const;
   inline std::shared_ptr<PerIsolateOptions> options();
+
+  inline bool uses_node_allocator() const;
+  inline v8::ArrayBuffer::Allocator* allocator() const;
+  inline ArrayBufferAllocator* node_allocator() const;
 
 #define VP(PropertyName, StringValue) V(v8::Private, PropertyName)
 #define VY(PropertyName, StringValue) V(v8::Symbol, PropertyName)
@@ -401,7 +405,9 @@ class IsolateData {
 
   v8::Isolate* const isolate_;
   uv_loop_t* const event_loop_;
-  uint32_t* const zero_fill_field_;
+  v8::ArrayBuffer::Allocator* const allocator_;
+  ArrayBufferAllocator* const node_allocator_;
+  const bool uses_node_allocator_;
   MultiIsolatePlatform* platform_;
   std::shared_ptr<PerIsolateOptions> options_;
 

--- a/src/env.h
+++ b/src/env.h
@@ -434,6 +434,38 @@ enum class DebugCategory {
   CATEGORY_COUNT
 };
 
+// A unique-pointer-ish object that is compatible with the JS engine's
+// ArrayBuffer::Allocator.
+struct AllocatedBuffer {
+ public:
+  explicit inline AllocatedBuffer(Environment* env = nullptr);
+  inline AllocatedBuffer(Environment* env, uv_buf_t buf);
+  inline ~AllocatedBuffer();
+  inline void Resize(size_t len);
+
+  inline uv_buf_t release();
+  inline char* data();
+  inline const char* data() const;
+  inline size_t size() const;
+  inline void clear();
+
+  inline v8::MaybeLocal<v8::Object> ToBuffer();
+  inline v8::Local<v8::ArrayBuffer> ToArrayBuffer();
+
+  inline AllocatedBuffer(AllocatedBuffer&& other);
+  inline AllocatedBuffer& operator=(AllocatedBuffer&& other);
+  AllocatedBuffer(const AllocatedBuffer& other) = delete;
+  AllocatedBuffer& operator=(const AllocatedBuffer& other) = delete;
+
+ private:
+  Environment* env_;
+  // We do not pass this to libuv directly, but uv_buf_t is a convenient way
+  // to represent a chunk of memory, and plays nicely with other parts of core.
+  uv_buf_t buffer_;
+
+  friend class Environment;
+};
+
 class Environment {
  public:
   class AsyncHooks {
@@ -647,6 +679,15 @@ class Environment {
   inline uint64_t timer_base() const;
 
   inline IsolateData* isolate_data() const;
+
+  // Utilites that allocate memory using the Isolate's ArrayBuffer::Allocator.
+  // In particular, using AllocateManaged() will provide a RAII-style object
+  // with easy conversion to `Buffer` and `ArrayBuffer` objects.
+  inline AllocatedBuffer AllocateManaged(size_t size, bool checked = true);
+  inline char* Allocate(size_t size);
+  inline char* AllocateUnchecked(size_t size);
+  char* Reallocate(char* data, size_t old_size, size_t size);
+  inline void Free(char* data, size_t size);
 
   inline bool printed_error() const;
   inline void set_printed_error(bool value);

--- a/src/node.cc
+++ b/src/node.cc
@@ -629,6 +629,77 @@ void* ArrayBufferAllocator::Allocate(size_t size) {
     return UncheckedMalloc(size);
 }
 
+DebuggingArrayBufferAllocator::~DebuggingArrayBufferAllocator() {
+  CHECK(allocations_.empty());
+}
+
+void* DebuggingArrayBufferAllocator::Allocate(size_t size) {
+  Mutex::ScopedLock lock(mutex_);
+  void* data = ArrayBufferAllocator::Allocate(size);
+  RegisterPointerInternal(data, size);
+  return data;
+}
+
+void* DebuggingArrayBufferAllocator::AllocateUninitialized(size_t size) {
+  Mutex::ScopedLock lock(mutex_);
+  void* data = ArrayBufferAllocator::AllocateUninitialized(size);
+  RegisterPointerInternal(data, size);
+  return data;
+}
+
+void DebuggingArrayBufferAllocator::Free(void* data, size_t size) {
+  Mutex::ScopedLock lock(mutex_);
+  UnregisterPointerInternal(data, size);
+  ArrayBufferAllocator::Free(data, size);
+}
+
+void* DebuggingArrayBufferAllocator::Reallocate(void* data,
+                                                size_t old_size,
+                                                size_t size) {
+  Mutex::ScopedLock lock(mutex_);
+  void* ret = ArrayBufferAllocator::Reallocate(data, old_size, size);
+  if (ret == nullptr) {
+    if (size == 0)  // i.e. equivalent to free().
+      UnregisterPointerInternal(data, old_size);
+    return nullptr;
+  }
+
+  if (data != nullptr) {
+    auto it = allocations_.find(data);
+    CHECK_NE(it, allocations_.end());
+    allocations_.erase(it);
+  }
+
+  RegisterPointerInternal(ret, size);
+  return ret;
+}
+
+void DebuggingArrayBufferAllocator::RegisterPointer(void* data, size_t size) {
+  Mutex::ScopedLock lock(mutex_);
+  RegisterPointerInternal(data, size);
+}
+
+void DebuggingArrayBufferAllocator::UnregisterPointer(void* data, size_t size) {
+  Mutex::ScopedLock lock(mutex_);
+  UnregisterPointerInternal(data, size);
+}
+
+void DebuggingArrayBufferAllocator::UnregisterPointerInternal(void* data,
+                                                              size_t size) {
+  if (data == nullptr) return;
+  auto it = allocations_.find(data);
+  CHECK_NE(it, allocations_.end());
+  CHECK_EQ(it->second, size);
+  allocations_.erase(it);
+}
+
+void DebuggingArrayBufferAllocator::RegisterPointerInternal(void* data,
+                                                            size_t size) {
+  if (data == nullptr) return;
+  CHECK_EQ(allocations_.count(data), 0);
+  allocations_[data] = size;
+}
+
 namespace {
 
 bool ShouldAbortOnUncaughtException(Isolate* isolate) {
@@ -2805,7 +2876,10 @@ int EmitExit(Environment* env) {
 
 
 ArrayBufferAllocator* CreateArrayBufferAllocator() {
-  return new ArrayBufferAllocator();
+  if (per_process_opts->debug_arraybuffer_allocations)
+    return new DebuggingArrayBufferAllocator();
+  else
+    return new ArrayBufferAllocator();
 }
 
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2832,7 +2832,7 @@ IsolateData* CreateIsolateData(
     uv_loop_t* loop,
     MultiIsolatePlatform* platform,
     ArrayBufferAllocator* allocator) {
-  return new IsolateData(isolate, loop, platform, allocator->zero_fill_field());
+  return new IsolateData(isolate, loop, platform, allocator);
 }
 
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -256,7 +256,10 @@ MaybeLocal<Object> New(Isolate* isolate, size_t length) {
   EscapableHandleScope handle_scope(isolate);
   Local<Object> obj;
   Environment* env = Environment::GetCurrent(isolate);
-  CHECK_NOT_NULL(env);  // TODO(addaleax): Handle nullptr here.
+  if (env == nullptr) {
+    THROW_ERR_BUFFER_CONTEXT_NOT_AVAILABLE(isolate);
+    return MaybeLocal<Object>();
+  }
   if (Buffer::New(env, length).ToLocal(&obj))
     return handle_scope.Escape(obj);
   return Local<Object>();
@@ -287,7 +290,10 @@ MaybeLocal<Object> New(Environment* env, size_t length) {
 MaybeLocal<Object> Copy(Isolate* isolate, const char* data, size_t length) {
   EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  CHECK_NOT_NULL(env);  // TODO(addaleax): Handle nullptr here.
+  if (env == nullptr) {
+    THROW_ERR_BUFFER_CONTEXT_NOT_AVAILABLE(isolate);
+    return MaybeLocal<Object>();
+  }
   Local<Object> obj;
   if (Buffer::Copy(env, data, length).ToLocal(&obj))
     return handle_scope.Escape(obj);
@@ -325,7 +331,11 @@ MaybeLocal<Object> New(Isolate* isolate,
                        void* hint) {
   EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  CHECK_NOT_NULL(env);  // TODO(addaleax): Handle nullptr here.
+  if (env == nullptr) {
+    callback(data, hint);
+    THROW_ERR_BUFFER_CONTEXT_NOT_AVAILABLE(isolate);
+    return MaybeLocal<Object>();
+  }
   Local<Object> obj;
   if (Buffer::New(env, data, length, callback, hint).ToLocal(&obj))
     return handle_scope.Escape(obj);
@@ -365,7 +375,11 @@ MaybeLocal<Object> New(Environment* env,
 MaybeLocal<Object> New(Isolate* isolate, char* data, size_t length) {
   EscapableHandleScope handle_scope(isolate);
   Environment* env = Environment::GetCurrent(isolate);
-  CHECK_NOT_NULL(env);  // TODO(addaleax): Handle nullptr here.
+  if (env == nullptr) {
+    free(data);
+    THROW_ERR_BUFFER_CONTEXT_NOT_AVAILABLE(isolate);
+    return MaybeLocal<Object>();
+  }
   Local<Object> obj;
   if (Buffer::New(env, data, length, true).ToLocal(&obj))
     return handle_scope.Escape(obj);

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -355,11 +355,6 @@ MaybeLocal<Object> New(Environment* env,
   }
 
   Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), data, length);
-  // `Neuter()`ing is required here to prevent materialization of the backing
-  // store in v8. `nullptr` buffers are not writable, so this is semantically
-  // correct.
-  if (data == nullptr)
-    ab->Neuter();
   MaybeLocal<Uint8Array> ui = Buffer::New(env, ab, 0, length);
 
   if (ui.IsEmpty()) {

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1556,6 +1556,24 @@ static void AddFingerprintDigest(const unsigned char* md,
   }
 }
 
+static MaybeLocal<Object> ECPointToBuffer(Environment* env,
+                                          const EC_GROUP* group,
+                                          const EC_POINT* point,
+                                          point_conversion_form_t form) {
+  size_t len = EC_POINT_point2oct(group, point, form, nullptr, 0, nullptr);
+  if (len == 0) {
+    env->ThrowError("Failed to get public key length");
+    return MaybeLocal<Object>();
+  }
+  MallocedBuffer<unsigned char> buf(len);
+  len = EC_POINT_point2oct(group, point, form, buf.data, buf.size, nullptr);
+  if (len == 0) {
+    env->ThrowError("Failed to get public key");
+    return MaybeLocal<Object>();
+  }
+  return Buffer::New(env, buf.release(), len);
+}
+
 static Local<Object> X509ToObject(Environment* env, X509* cert) {
   EscapableHandleScope scope(env->isolate());
   Local<Context> context = env->context();
@@ -4460,26 +4478,14 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   if (pub == nullptr)
     return env->ThrowError("Failed to get ECDH public key");
 
-  int size;
   CHECK(args[0]->IsUint32());
   uint32_t val = args[0].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
-  size = EC_POINT_point2oct(ecdh->group_, pub, form, nullptr, 0, nullptr);
-  if (size == 0)
-    return env->ThrowError("Failed to get public key length");
-
-  unsigned char* out = node::Malloc<unsigned char>(size);
-
-  int r = EC_POINT_point2oct(ecdh->group_, pub, form, out, size, nullptr);
-  if (r != size) {
-    free(out);
-    return env->ThrowError("Failed to get public key");
-  }
-
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), size).ToLocalChecked();
-  args.GetReturnValue().Set(buf);
+  MaybeLocal<Object> buf =
+      ECPointToBuffer(env, EC_KEY_get0_group(ecdh->key_.get()), pub, form);
+  if (buf.IsEmpty()) return;
+  args.GetReturnValue().Set(buf.ToLocalChecked());
 }
 
 
@@ -5082,23 +5088,9 @@ void ConvertKey(const FunctionCallbackInfo<Value>& args) {
   uint32_t val = args[2].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
-  int size = EC_POINT_point2oct(
-      group.get(), pub.get(), form, nullptr, 0, nullptr);
-
-  if (size == 0)
-    return env->ThrowError("Failed to get public key length");
-
-  unsigned char* out = node::Malloc<unsigned char>(size);
-
-  int r = EC_POINT_point2oct(group.get(), pub.get(), form, out, size, nullptr);
-  if (r != size) {
-    free(out);
-    return env->ThrowError("Failed to get public key");
-  }
-
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), size).ToLocalChecked();
-  args.GetReturnValue().Set(buf);
+  MaybeLocal<Object> buf = ECPointToBuffer(env, group.get(), pub.get(), form);
+  if (buf.IsEmpty()) return;
+  args.GetReturnValue().Set(buf.ToLocalChecked());
 }
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1556,23 +1556,26 @@ static void AddFingerprintDigest(const unsigned char* md,
   }
 }
 
+
 static MaybeLocal<Object> ECPointToBuffer(Environment* env,
                                           const EC_GROUP* group,
                                           const EC_POINT* point,
-                                          point_conversion_form_t form) {
+                                          point_conversion_form_t form,
+                                          const char** error) {
   size_t len = EC_POINT_point2oct(group, point, form, nullptr, 0, nullptr);
   if (len == 0) {
-    env->ThrowError("Failed to get public key length");
+    if (error != nullptr) *error = "Failed to get public key length";
     return MaybeLocal<Object>();
   }
   MallocedBuffer<unsigned char> buf(len);
   len = EC_POINT_point2oct(group, point, form, buf.data, buf.size, nullptr);
   if (len == 0) {
-    env->ThrowError("Failed to get public key");
+    if (error != nullptr) *error = "Failed to get public key";
     return MaybeLocal<Object>();
   }
   return Buffer::New(env, buf.release(), len);
 }
+
 
 static Local<Object> X509ToObject(Environment* env, X509* cert) {
   EscapableHandleScope scope(env->isolate());
@@ -4474,6 +4477,7 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   ECDH* ecdh;
   ASSIGN_OR_RETURN_UNWRAP(&ecdh, args.Holder());
 
+  const EC_GROUP* group = EC_KEY_get0_group(ecdh->key_.get());
   const EC_POINT* pub = EC_KEY_get0_public_key(ecdh->key_.get());
   if (pub == nullptr)
     return env->ThrowError("Failed to get ECDH public key");
@@ -4482,10 +4486,11 @@ void ECDH::GetPublicKey(const FunctionCallbackInfo<Value>& args) {
   uint32_t val = args[0].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
-  MaybeLocal<Object> buf =
-      ECPointToBuffer(env, EC_KEY_get0_group(ecdh->key_.get()), pub, form);
-  if (buf.IsEmpty()) return;
-  args.GetReturnValue().Set(buf.ToLocalChecked());
+  const char* error;
+  Local<Object> buf;
+  if (!ECPointToBuffer(env, group, pub, form, &error).ToLocal(&buf))
+    return env->ThrowError(error);
+  args.GetReturnValue().Set(buf);
 }
 
 
@@ -5088,9 +5093,11 @@ void ConvertKey(const FunctionCallbackInfo<Value>& args) {
   uint32_t val = args[2].As<Uint32>()->Value();
   point_conversion_form_t form = static_cast<point_conversion_form_t>(val);
 
-  MaybeLocal<Object> buf = ECPointToBuffer(env, group.get(), pub.get(), form);
-  if (buf.IsEmpty()) return;
-  args.GetReturnValue().Set(buf.ToLocalChecked());
+  const char* error;
+  Local<Object> buf;
+  if (!ECPointToBuffer(env, group.get(), pub.get(), form, &error).ToLocal(&buf))
+    return env->ThrowError(error);
+  args.GetReturnValue().Set(buf);
 }
 
 

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -323,6 +323,14 @@ bool EntropySource(unsigned char* buffer, size_t length) {
 }
 
 
+template <typename T>
+static T* MallocOpenSSL(size_t count) {
+  void* mem = OPENSSL_malloc(MultiplyWithOverflowCheck(count, sizeof(T)));
+  CHECK_IMPLIES(mem == nullptr, count == 0);
+  return static_cast<T*>(mem);
+}
+
+
 void SecureContext::Initialize(Environment* env, Local<Object> target) {
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -2355,12 +2363,11 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
     size_t len = Buffer::Length(obj);
 
     // OpenSSL takes control of the pointer after accepting it
-    auto* allocator = env->isolate()->GetArrayBufferAllocator();
-    uint8_t* data = static_cast<uint8_t*>(allocator->AllocateUninitialized(len));
+    unsigned char* data = MallocOpenSSL<unsigned char>(len);
     memcpy(data, resp, len);
 
     if (!SSL_set_tlsext_status_ocsp_resp(s, data, len))
-      allocator->Free(data, len);
+      OPENSSL_free(data);
     w->ocsp_response_.Reset();
 
     return SSL_TLSEXT_ERR_OK;

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1556,7 +1556,6 @@ static void AddFingerprintDigest(const unsigned char* md,
   }
 }
 
-
 static MaybeLocal<Object> ECPointToBuffer(Environment* env,
                                           const EC_GROUP* group,
                                           const EC_POINT* point,
@@ -1567,15 +1566,19 @@ static MaybeLocal<Object> ECPointToBuffer(Environment* env,
     if (error != nullptr) *error = "Failed to get public key length";
     return MaybeLocal<Object>();
   }
-  MallocedBuffer<unsigned char> buf(len);
-  len = EC_POINT_point2oct(group, point, form, buf.data, buf.size, nullptr);
+  AllocatedBuffer buf = env->AllocateManaged(len);
+  len = EC_POINT_point2oct(group,
+                           point,
+                           form,
+                           reinterpret_cast<unsigned char*>(buf.data()),
+                           buf.size(),
+                           nullptr);
   if (len == 0) {
     if (error != nullptr) *error = "Failed to get public key";
     return MaybeLocal<Object>();
   }
-  return Buffer::New(env, buf.release(), len);
+  return buf.ToBuffer();
 }
-
 
 static Local<Object> X509ToObject(Environment* env, X509* cert) {
   EscapableHandleScope scope(env->isolate());
@@ -1888,9 +1891,9 @@ void SSLWrap<Base>::GetFinished(const FunctionCallbackInfo<Value>& args) {
   if (len == 0)
     return;
 
-  char* buf = Malloc(len);
-  CHECK_EQ(len, SSL_get_finished(w->ssl_.get(), buf, len));
-  args.GetReturnValue().Set(Buffer::New(env, buf, len).ToLocalChecked());
+  AllocatedBuffer buf = env->AllocateManaged(len);
+  CHECK_EQ(len, SSL_get_finished(w->ssl_.get(), buf.data(), len));
+  args.GetReturnValue().Set(buf.ToBuffer().ToLocalChecked());
 }
 
 
@@ -1911,9 +1914,9 @@ void SSLWrap<Base>::GetPeerFinished(const FunctionCallbackInfo<Value>& args) {
   if (len == 0)
     return;
 
-  char* buf = Malloc(len);
-  CHECK_EQ(len, SSL_get_peer_finished(w->ssl_.get(), buf, len));
-  args.GetReturnValue().Set(Buffer::New(env, buf, len).ToLocalChecked());
+  AllocatedBuffer buf = env->AllocateManaged(len);
+  CHECK_EQ(len, SSL_get_peer_finished(w->ssl_.get(), buf.data(), len));
+  args.GetReturnValue().Set(buf.ToBuffer().ToLocalChecked());
 }
 
 
@@ -1931,10 +1934,10 @@ void SSLWrap<Base>::GetSession(const FunctionCallbackInfo<Value>& args) {
   int slen = i2d_SSL_SESSION(sess, nullptr);
   CHECK_GT(slen, 0);
 
-  char* sbuf = Malloc(slen);
-  unsigned char* p = reinterpret_cast<unsigned char*>(sbuf);
+  AllocatedBuffer sbuf = env->AllocateManaged(slen);
+  unsigned char* p = reinterpret_cast<unsigned char*>(sbuf.data());
   i2d_SSL_SESSION(sess, &p);
-  args.GetReturnValue().Set(Buffer::New(env, sbuf, slen).ToLocalChecked());
+  args.GetReturnValue().Set(sbuf.ToBuffer().ToLocalChecked());
 }
 
 
@@ -2352,11 +2355,12 @@ int SSLWrap<Base>::TLSExtStatusCallback(SSL* s, void* arg) {
     size_t len = Buffer::Length(obj);
 
     // OpenSSL takes control of the pointer after accepting it
-    char* data = node::Malloc(len);
+    auto* allocator = env->isolate()->GetArrayBufferAllocator();
+    uint8_t* data = static_cast<uint8_t*>(allocator->AllocateUninitialized(len));
     memcpy(data, resp, len);
 
     if (!SSL_set_tlsext_status_ocsp_resp(s, data, len))
-      free(data);
+      allocator->Free(data, len);
     w->ocsp_response_.Reset();
 
     return SSL_TLSEXT_ERR_OK;
@@ -3036,11 +3040,9 @@ void CipherBase::SetAAD(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(b);  // Possibly report invalid state failure
 }
 
-
 CipherBase::UpdateResult CipherBase::Update(const char* data,
                                             int len,
-                                            unsigned char** out,
-                                            int* out_len) {
+                                            AllocatedBuffer* out) {
   if (!ctx_)
     return kErrorState;
   MarkPopErrorOnReturn mark_pop_error_on_return;
@@ -3058,27 +3060,27 @@ CipherBase::UpdateResult CipherBase::Update(const char* data,
     CHECK(MaybePassAuthTagToOpenSSL());
   }
 
-  *out_len = 0;
-  int buff_len = len + EVP_CIPHER_CTX_block_size(ctx_.get());
+  int buf_len = len + EVP_CIPHER_CTX_block_size(ctx_.get());
   // For key wrapping algorithms, get output size by calling
   // EVP_CipherUpdate() with null output.
   if (kind_ == kCipher && mode == EVP_CIPH_WRAP_MODE &&
       EVP_CipherUpdate(ctx_.get(),
                        nullptr,
-                       &buff_len,
+                       &buf_len,
                        reinterpret_cast<const unsigned char*>(data),
                        len) != 1) {
     return kErrorState;
   }
 
-  *out = Malloc<unsigned char>(buff_len);
+  *out = env()->AllocateManaged(buf_len);
   int r = EVP_CipherUpdate(ctx_.get(),
-                           *out,
-                           out_len,
+                           reinterpret_cast<unsigned char*>(out->data()),
+                           &buf_len,
                            reinterpret_cast<const unsigned char*>(data),
                            len);
 
-  CHECK_LE(*out_len, buff_len);
+  CHECK_LE(static_cast<size_t>(buf_len), out->size());
+  out->Resize(buf_len);
 
   // When in CCM mode, EVP_CipherUpdate will fail if the authentication tag is
   // invalid. In that case, remember the error and throw in final().
@@ -3096,9 +3098,8 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
   CipherBase* cipher;
   ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
 
-  unsigned char* out = nullptr;
+  AllocatedBuffer out;
   UpdateResult r;
-  int out_len = 0;
 
   // Only copy the data if we have to, because it's a string
   if (args[0]->IsString()) {
@@ -3106,15 +3107,14 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
     if (!decoder.Decode(env, args[0].As<String>(), args[1], UTF8)
              .FromMaybe(false))
       return;
-    r = cipher->Update(decoder.out(), decoder.size(), &out, &out_len);
+    r = cipher->Update(decoder.out(), decoder.size(), &out);
   } else {
     char* buf = Buffer::Data(args[0]);
     size_t buflen = Buffer::Length(args[0]);
-    r = cipher->Update(buf, buflen, &out, &out_len);
+    r = cipher->Update(buf, buflen, &out);
   }
 
   if (r != kSuccess) {
-    free(out);
     if (r == kErrorState) {
       ThrowCryptoError(env, ERR_get_error(),
                        "Trying to add data in unsupported state");
@@ -3122,11 +3122,9 @@ void CipherBase::Update(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  CHECK(out != nullptr || out_len == 0);
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), out_len).ToLocalChecked();
+  CHECK(out.data() != nullptr || out.size() == 0);
 
-  args.GetReturnValue().Set(buf);
+  args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
 
@@ -3146,14 +3144,13 @@ void CipherBase::SetAutoPadding(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(b);  // Possibly report invalid state failure
 }
 
-
-bool CipherBase::Final(unsigned char** out, int* out_len) {
+bool CipherBase::Final(AllocatedBuffer* out) {
   if (!ctx_)
     return false;
 
   const int mode = EVP_CIPHER_CTX_mode(ctx_.get());
 
-  *out = Malloc<unsigned char>(
+  *out = env()->AllocateManaged(
       static_cast<size_t>(EVP_CIPHER_CTX_block_size(ctx_.get())));
 
   if (kind_ == kDecipher && IsSupportedAuthenticatedMode(mode)) {
@@ -3165,8 +3162,17 @@ bool CipherBase::Final(unsigned char** out, int* out_len) {
   bool ok;
   if (kind_ == kDecipher && mode == EVP_CIPH_CCM_MODE) {
     ok = !pending_auth_failed_;
+    *out = AllocatedBuffer(env());  // Empty buffer.
   } else {
-    ok = EVP_CipherFinal_ex(ctx_.get(), *out, out_len) == 1;
+    int out_len = out->size();
+    ok = EVP_CipherFinal_ex(ctx_.get(),
+                            reinterpret_cast<unsigned char*>(out->data()),
+                            &out_len) == 1;
+
+    if (out_len >= 0)
+      out->Resize(out_len);
+    else
+      *out = AllocatedBuffer();  // *out will not be used.
 
     if (ok && kind_ == kCipher && IsAuthenticatedMode()) {
       // In GCM mode, the authentication tag length can be specified in advance,
@@ -3195,33 +3201,21 @@ void CipherBase::Final(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&cipher, args.Holder());
   if (cipher->ctx_ == nullptr) return env->ThrowError("Unsupported state");
 
-  unsigned char* out_value = nullptr;
-  int out_len = -1;
+  AllocatedBuffer out;
 
   // Check IsAuthenticatedMode() first, Final() destroys the EVP_CIPHER_CTX.
   const bool is_auth_mode = cipher->IsAuthenticatedMode();
-  bool r = cipher->Final(&out_value, &out_len);
+  bool r = cipher->Final(&out);
 
-  if (out_len <= 0 || !r) {
-    free(out_value);
-    out_value = nullptr;
-    out_len = 0;
-    if (!r) {
-      const char* msg = is_auth_mode ?
-          "Unsupported state or unable to authenticate data" :
-          "Unsupported state";
+  if (!r) {
+    const char* msg = is_auth_mode
+                          ? "Unsupported state or unable to authenticate data"
+                          : "Unsupported state";
 
-      return ThrowCryptoError(env,
-                              ERR_get_error(),
-                              msg);
-    }
+    return ThrowCryptoError(env, ERR_get_error(), msg);
   }
 
-  Local<Object> buf = Buffer::New(
-      env,
-      reinterpret_cast<char*>(out_value),
-      out_len).ToLocalChecked();
-  args.GetReturnValue().Set(buf);
+  args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
 
@@ -3848,18 +3842,17 @@ void Verify::VerifyFinal(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(verify_result);
 }
 
-
 template <PublicKeyCipher::Operation operation,
           PublicKeyCipher::EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
           PublicKeyCipher::EVP_PKEY_cipher_t EVP_PKEY_cipher>
-bool PublicKeyCipher::Cipher(const char* key_pem,
+bool PublicKeyCipher::Cipher(Environment* env,
+                             const char* key_pem,
                              int key_pem_len,
                              const char* passphrase,
                              int padding,
                              const unsigned char* data,
                              int len,
-                             unsigned char** out,
-                             size_t* out_len) {
+                             AllocatedBuffer* out) {
   EVPKeyPointer pkey;
 
   // Check if this is a PKCS#8 or RSA public key before trying as X.509 and
@@ -3890,14 +3883,21 @@ bool PublicKeyCipher::Cipher(const char* key_pem,
   if (EVP_PKEY_CTX_set_rsa_padding(ctx.get(), padding) <= 0)
     return false;
 
-  if (EVP_PKEY_cipher(ctx.get(), nullptr, out_len, data, len) <= 0)
+  size_t out_len = 0;
+  if (EVP_PKEY_cipher(ctx.get(), nullptr, &out_len, data, len) <= 0)
     return false;
 
-  *out = Malloc<unsigned char>(*out_len);
+  *out = env->AllocateManaged(out_len);
 
-  if (EVP_PKEY_cipher(ctx.get(), *out, out_len, data, len) <= 0)
+  if (EVP_PKEY_cipher(ctx.get(),
+                      reinterpret_cast<unsigned char*>(out->data()),
+                      &out_len,
+                      data,
+                      len) <= 0) {
     return false;
+  }
 
+  out->Resize(out_len);
   return true;
 }
 
@@ -3921,35 +3921,24 @@ void PublicKeyCipher::Cipher(const FunctionCallbackInfo<Value>& args) {
 
   String::Utf8Value passphrase(args.GetIsolate(), args[3]);
 
-  unsigned char* out_value = nullptr;
-  size_t out_len = 0;
+  AllocatedBuffer out;
 
   ClearErrorOnReturn clear_error_on_return;
 
   bool r = Cipher<operation, EVP_PKEY_cipher_init, EVP_PKEY_cipher>(
+      env,
       kbuf,
       klen,
       args.Length() >= 4 && !args[3]->IsNull() ? *passphrase : nullptr,
       padding,
       reinterpret_cast<const unsigned char*>(buf),
       len,
-      &out_value,
-      &out_len);
+      &out);
 
-  if (out_len == 0 || !r) {
-    free(out_value);
-    out_value = nullptr;
-    out_len = 0;
-    if (!r) {
-      return ThrowCryptoError(env,
-        ERR_get_error());
-    }
-  }
+  if (!r)
+    return ThrowCryptoError(env, ERR_get_error());
 
-  Local<Object> vbuf =
-      Buffer::New(env, reinterpret_cast<char*>(out_value), out_len)
-      .ToLocalChecked();
-  args.GetReturnValue().Set(vbuf);
+  args.GetReturnValue().Set(out.ToBuffer().ToLocalChecked());
 }
 
 
@@ -4150,9 +4139,9 @@ void DiffieHellman::GenerateKeys(const FunctionCallbackInfo<Value>& args) {
   const BIGNUM* pub_key;
   DH_get0_key(diffieHellman->dh_.get(), &pub_key, nullptr);
   size_t size = BN_num_bytes(pub_key);
-  char* data = Malloc(size);
-  BN_bn2bin(pub_key, reinterpret_cast<unsigned char*>(data));
-  args.GetReturnValue().Set(Buffer::New(env, data, size).ToLocalChecked());
+  AllocatedBuffer data = env->AllocateManaged(size);
+  BN_bn2bin(pub_key, reinterpret_cast<unsigned char*>(data.data()));
+  args.GetReturnValue().Set(data.ToBuffer().ToLocalChecked());
 }
 
 
@@ -4169,9 +4158,9 @@ void DiffieHellman::GetField(const FunctionCallbackInfo<Value>& args,
   if (num == nullptr) return env->ThrowError(err_if_null);
 
   size_t size = BN_num_bytes(num);
-  char* data = Malloc(size);
-  BN_bn2bin(num, reinterpret_cast<unsigned char*>(data));
-  args.GetReturnValue().Set(Buffer::New(env, data, size).ToLocalChecked());
+  AllocatedBuffer data = env->AllocateManaged(size);
+  BN_bn2bin(num, reinterpret_cast<unsigned char*>(data.data()));
+  args.GetReturnValue().Set(data.ToBuffer().ToLocalChecked());
 }
 
 void DiffieHellman::GetPrime(const FunctionCallbackInfo<Value>& args) {
@@ -4233,9 +4222,9 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
       Buffer::Length(args[0]),
       0));
 
-  MallocedBuffer<char> data(DH_size(diffieHellman->dh_.get()));
+  AllocatedBuffer ret = env->AllocateManaged(DH_size(diffieHellman->dh_.get()));
 
-  int size = DH_compute_key(reinterpret_cast<unsigned char*>(data.data),
+  int size = DH_compute_key(reinterpret_cast<unsigned char*>(ret.data()),
                             key.get(),
                             diffieHellman->dh_.get());
 
@@ -4270,14 +4259,13 @@ void DiffieHellman::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   // DH_compute_key returns number of bytes in a remainder of exponent, which
   // may have less bytes than a prime number. Therefore add 0-padding to the
   // allocated buffer.
-  if (static_cast<size_t>(size) != data.size) {
-    CHECK_GT(data.size, static_cast<size_t>(size));
-    memmove(data.data + data.size - size, data.data, size);
-    memset(data.data, 0, data.size - size);
+  if (static_cast<size_t>(size) != ret.size()) {
+    CHECK_GT(ret.size(), static_cast<size_t>(size));
+    memmove(ret.data() + ret.size() - size, ret.data(), size);
+    memset(ret.data(), 0, ret.size() - size);
   }
 
-  args.GetReturnValue().Set(
-      Buffer::New(env->isolate(), data.release(), data.size).ToLocalChecked());
+  args.GetReturnValue().Set(ret.ToBuffer().ToLocalChecked());
 }
 
 void DiffieHellman::SetKey(const v8::FunctionCallbackInfo<Value>& args,
@@ -4455,15 +4443,14 @@ void ECDH::ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   // NOTE: field_size is in bits
   int field_size = EC_GROUP_get_degree(ecdh->group_);
   size_t out_len = (field_size + 7) / 8;
-  char* out = node::Malloc(out_len);
+  AllocatedBuffer out = env->AllocateManaged(out_len);
 
-  int r = ECDH_compute_key(out, out_len, pub.get(), ecdh->key_.get(), nullptr);
-  if (!r) {
-    free(out);
+  int r = ECDH_compute_key(
+      out.data(), out_len, pub.get(), ecdh->key_.get(), nullptr);
+  if (!r)
     return env->ThrowError("Failed to compute ECDH key");
-  }
 
-  Local<Object> buf = Buffer::New(env, out, out_len).ToLocalChecked();
+  Local<Object> buf = out.ToBuffer().ToLocalChecked();
   args.GetReturnValue().Set(buf);
 }
 
@@ -4505,15 +4492,13 @@ void ECDH::GetPrivateKey(const FunctionCallbackInfo<Value>& args) {
     return env->ThrowError("Failed to get ECDH private key");
 
   int size = BN_num_bytes(b);
-  unsigned char* out = node::Malloc<unsigned char>(size);
+  AllocatedBuffer out = env->AllocateManaged(size);
 
-  if (size != BN_bn2bin(b, out)) {
-    free(out);
+  if (size != BN_bn2bin(b, reinterpret_cast<unsigned char*>(out.data()))) {
     return env->ThrowError("Failed to convert ECDH private key to Buffer");
   }
 
-  Local<Object> buf =
-      Buffer::New(env, reinterpret_cast<char*>(out), size).ToLocalChecked();
+  Local<Object> buf = out.ToBuffer().ToLocalChecked();
   args.GetReturnValue().Set(buf);
 }
 
@@ -4976,31 +4961,28 @@ void VerifySpkac(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(verify_result);
 }
 
-
-char* ExportPublicKey(const char* data, int len, size_t* size) {
-  char* buf = nullptr;
-
+AllocatedBuffer ExportPublicKey(Environment* env,
+                                const char* data,
+                                int len,
+                                size_t* size) {
   BIOPointer bio(BIO_new(BIO_s_mem()));
-  if (!bio)
-    return nullptr;
+  if (!bio) return AllocatedBuffer();
 
   NetscapeSPKIPointer spki(NETSCAPE_SPKI_b64_decode(data, len));
-  if (!spki)
-    return nullptr;
+  if (!spki) return AllocatedBuffer();
 
   EVPKeyPointer pkey(NETSCAPE_SPKI_get_pubkey(spki.get()));
-  if (!pkey)
-    return nullptr;
+  if (!pkey) return AllocatedBuffer();
 
   if (PEM_write_bio_PUBKEY(bio.get(), pkey.get()) <= 0)
-    return nullptr;
+    return AllocatedBuffer();
 
   BUF_MEM* ptr;
   BIO_get_mem_ptr(bio.get(), &ptr);
 
   *size = ptr->length;
-  buf = Malloc(*size);
-  memcpy(buf, ptr->data, *size);
+  AllocatedBuffer buf = env->AllocateManaged(*size);
+  memcpy(buf.data(), ptr->data, *size);
 
   return buf;
 }
@@ -5017,12 +4999,11 @@ void ExportPublicKey(const FunctionCallbackInfo<Value>& args) {
   CHECK_NOT_NULL(data);
 
   size_t pkey_size;
-  char* pkey = ExportPublicKey(data, length, &pkey_size);
-  if (pkey == nullptr)
+  AllocatedBuffer pkey = ExportPublicKey(env, data, length, &pkey_size);
+  if (pkey.data() == nullptr)
     return args.GetReturnValue().SetEmptyString();
 
-  Local<Value> out = Buffer::New(env, pkey, pkey_size).ToLocalChecked();
-  args.GetReturnValue().Set(out);
+  args.GetReturnValue().Set(pkey.ToBuffer().ToLocalChecked());
 }
 
 

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -383,9 +383,8 @@ class CipherBase : public BaseObject {
   bool InitAuthenticated(const char* cipher_type, int iv_len,
                          unsigned int auth_tag_len);
   bool CheckCCMMessageLength(int message_len);
-  UpdateResult Update(const char* data, int len, unsigned char** out,
-                      int* out_len);
-  bool Final(unsigned char** out, int* out_len);
+  UpdateResult Update(const char* data, int len, AllocatedBuffer* out);
+  bool Final(AllocatedBuffer* out);
   bool SetAutoPadding(bool auto_padding);
 
   bool IsAuthenticatedMode() const;
@@ -576,14 +575,14 @@ class PublicKeyCipher {
   template <Operation operation,
             EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
             EVP_PKEY_cipher_t EVP_PKEY_cipher>
-  static bool Cipher(const char* key_pem,
+  static bool Cipher(Environment* env,
+                     const char* key_pem,
                      int key_pem_len,
                      const char* passphrase,
                      int padding,
                      const unsigned char* data,
                      int len,
-                     unsigned char** out,
-                     size_t* out_len);
+                     AllocatedBuffer* out);
 
   template <Operation operation,
             EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -576,8 +576,7 @@ class PublicKeyCipher {
   template <Operation operation,
             EVP_PKEY_cipher_init_t EVP_PKEY_cipher_init,
             EVP_PKEY_cipher_t EVP_PKEY_cipher>
-  static bool Cipher(Environment* env,
-                     const char* key_pem,
+  static bool Cipher(const char* key_pem,
                      int key_pem_len,
                      const char* passphrase,
                      int padding,

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -17,6 +17,7 @@ namespace node {
 // a `Local<Value>` containing the TypeError with proper code and message
 
 #define ERRORS_WITH_CODE(V)                                                  \
+  V(ERR_BUFFER_CONTEXT_NOT_AVAILABLE, Error)                                 \
   V(ERR_BUFFER_OUT_OF_BOUNDS, RangeError)                                    \
   V(ERR_BUFFER_TOO_LARGE, Error)                                             \
   V(ERR_CANNOT_TRANSFER_OBJECT, TypeError)                                   \
@@ -55,6 +56,8 @@ namespace node {
 // Errors with predefined static messages
 
 #define PREDEFINED_ERROR_MESSAGES(V)                                         \
+  V(ERR_BUFFER_CONTEXT_NOT_AVAILABLE,                                        \
+    "Buffer is not available for the current Context")                       \
   V(ERR_CANNOT_TRANSFER_OBJECT, "Cannot transfer object of unsupported type")\
   V(ERR_CLOSED_MESSAGE_PORT, "Cannot send data on closed MessagePort")       \
   V(ERR_CONSTRUCT_CALL_REQUIRED, "Cannot call constructor without `new`")    \
@@ -73,8 +76,11 @@ namespace node {
   inline v8::Local<v8::Value> code(v8::Isolate* isolate) {                   \
     return code(isolate, message);                                           \
   }                                                                          \
+  inline void THROW_ ## code(v8::Isolate* isolate) {                         \
+    isolate->ThrowException(code(isolate, message));                         \
+  }                                                                          \
   inline void THROW_ ## code(Environment* env) {                             \
-    env->isolate()->ThrowException(code(env->isolate(), message));           \
+    THROW_ ## code(env->isolate());                                          \
   }
   PREDEFINED_ERROR_MESSAGES(V)
 #undef V

--- a/src/node_http2.h
+++ b/src/node_http2.h
@@ -779,6 +779,7 @@ class Http2Session : public AsyncWrap, public StreamListener {
   }
 
   // Handle reads/writes from the underlying network transport.
+  uv_buf_t OnStreamAlloc(size_t suggested_size) override;
   void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override;
   void OnStreamAfterWrite(WriteWrap* w, int status) override;
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -531,10 +531,9 @@ class Parser : public AsyncWrap, public StreamListener {
   uv_buf_t OnStreamAlloc(size_t suggested_size) override {
     // For most types of streams, OnStreamRead will be immediately after
     // OnStreamAlloc, and will consume all data, so using a static buffer for
-    // reading is more efficient. For other streams, just use the default
-    // allocator, which uses Malloc().
+    // reading is more efficient. For other streams, just use Malloc() directly.
     if (env()->http_parser_buffer_in_use())
-      return StreamListener::OnStreamAlloc(suggested_size);
+      return uv_buf_init(Malloc(suggested_size), suggested_size);
     env()->set_http_parser_buffer_in_use(true);
 
     if (env()->http_parser_buffer() == nullptr)

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -416,10 +416,12 @@ v8::MaybeLocal<v8::Object> New(Environment* env,
                                size_t length,
                                void (*callback)(char* data, void* hint),
                                void* hint);
-// Takes ownership of |data|.  Must allocate |data| with malloc() or realloc()
-// because ArrayBufferAllocator::Free() deallocates it again with free().
-// Mixing operator new and free() is undefined behavior so don't do that.
-v8::MaybeLocal<v8::Object> New(Environment* env, char* data, size_t length);
+// Takes ownership of |data|.  Must allocate |data| with the current Isolate's
+// ArrayBuffer::Allocator().
+v8::MaybeLocal<v8::Object> New(Environment* env,
+                               char* data,
+                               size_t length,
+                               bool uses_malloc);
 
 inline
 v8::MaybeLocal<v8::Uint8Array> New(Environment* env,
@@ -450,7 +452,7 @@ static v8::MaybeLocal<v8::Object> New(Environment* env,
   const size_t len_in_bytes = buf->length() * sizeof(buf->out()[0]);
 
   if (buf->IsAllocated())
-    ret = New(env, src, len_in_bytes);
+    ret = New(env, src, len_in_bytes, true);
   else if (!buf->IsInvalidated())
     ret = Copy(env, src, len_in_bytes);
 

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -398,13 +398,36 @@ class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
  public:
   inline uint32_t* zero_fill_field() { return &zero_fill_field_; }
 
-  virtual void* Allocate(size_t size);  // Defined in src/node.cc
-  virtual void* AllocateUninitialized(size_t size)
+  void* Allocate(size_t size) override;  // Defined in src/node.cc
+  void* AllocateUninitialized(size_t size) override
     { return node::UncheckedMalloc(size); }
-  virtual void Free(void* data, size_t) { free(data); }
+  void Free(void* data, size_t) override { free(data); }
+  virtual void* Reallocate(void* data, size_t old_size, size_t size) {
+    return static_cast<void*>(
+        UncheckedRealloc<char>(static_cast<char*>(data), size));
+  }
+  virtual void RegisterPointer(void* data, size_t size) {}
+  virtual void UnregisterPointer(void* data, size_t size) {}
 
  private:
   uint32_t zero_fill_field_ = 1;  // Boolean but exposed as uint32 to JS land.
+};
+
+class DebuggingArrayBufferAllocator final : public ArrayBufferAllocator {
+ public:
+  ~DebuggingArrayBufferAllocator() override;
+  void* Allocate(size_t size) override;
+  void* AllocateUninitialized(size_t size) override;
+  void Free(void* data, size_t size) override;
+  void* Reallocate(void* data, size_t old_size, size_t size) override;
+  void RegisterPointer(void* data, size_t size) override;
+  void UnregisterPointer(void* data, size_t size) override;
+
+ private:
+  void RegisterPointerInternal(void* data, size_t size);
+  void UnregisterPointerInternal(void* data, size_t size);
+  Mutex mutex_;
+  std::unordered_map<void*, size_t> allocations_;
 };
 
 namespace Buffer {

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -279,7 +279,8 @@ Maybe<bool> Message::Serialize(Environment* env,
         Local<ArrayBuffer> ab = entry.As<ArrayBuffer>();
         // If we cannot render the ArrayBuffer unusable in this Isolate and
         // take ownership of its memory, copying the buffer will have to do.
-        if (!ab->IsNeuterable() || ab->IsExternal())
+        if (!ab->IsNeuterable() || ab->IsExternal() ||
+            !env->isolate_data()->uses_node_allocator()) {
           continue;
         }
         // We simply use the array index in the `array_buffers` list as the

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -164,12 +164,8 @@ void ThrowDataCloneException(Environment* env, Local<String> message) {
 // DeserializerDelegate understands how to unpack.
 class SerializerDelegate : public ValueSerializer::Delegate {
  public:
-  SerializerDelegate(
-    Environment* env,
-    Local<Context> context,
-    Message* m,
-    v8::ArrayBuffer::Allocator *allocator)
-    : env_(env), context_(context), msg_(m), allocator_(allocator) {}
+  SerializerDelegate(Environment* env, Local<Context> context, Message* m)
+      : env_(env), context_(context), msg_(m) {}
 
   void ThrowDataCloneError(Local<String> message) override {
     ThrowDataCloneException(env_, message);
@@ -205,19 +201,6 @@ class SerializerDelegate : public ValueSerializer::Delegate {
     return Just(i);
   }
 
-  void FreeBufferMemory(void* buffer) override {
-    // the second parameter is unused, so pass 0 as a filler
-    return allocator_->Free(buffer, 0);
-  }
-
-  void* ReallocateBufferMemory(void* old_buffer,
-                               size_t size,
-                               size_t* actual_size) override {
-    auto result = allocator_->Realloc(old_buffer, size);
-    *actual_size = result ? size :0;
-    return result;
-  }
-
   void Finish() {
     // Only close the MessagePort handles and actually transfer them
     // once we know that serialization succeeded.
@@ -247,7 +230,6 @@ class SerializerDelegate : public ValueSerializer::Delegate {
   Message* msg_;
   std::vector<Local<SharedArrayBuffer>> seen_shared_array_buffers_;
   std::vector<MessagePort*> ports_;
-  v8::ArrayBuffer::Allocator* allocator_;
 
   friend class worker::Message;
 };
@@ -265,7 +247,7 @@ Maybe<bool> Message::Serialize(Environment* env,
   // Verify that we're not silently overwriting an existing message.
   CHECK(main_message_buf_.is_empty());
 
-  SerializerDelegate delegate(env, context, this, env->isolate()->GetArrayBufferAllocator());
+  SerializerDelegate delegate(env, context, this);
   ValueSerializer serializer(env->isolate(), &delegate);
   delegate.serializer = &serializer;
 
@@ -331,8 +313,7 @@ Maybe<bool> Message::Serialize(Environment* env,
     ab->Neuter();
     array_buffer_contents_.push_back(
         MallocedBuffer<char> { static_cast<char*>(contents.Data()),
-                               contents.ByteLength(),
-                               env->isolate()->GetArrayBufferAllocator() });
+                               contents.ByteLength() });
   }
 
   delegate.Finish();
@@ -340,7 +321,7 @@ Maybe<bool> Message::Serialize(Environment* env,
   // The serializer gave us a buffer allocated using `malloc()`.
   std::pair<uint8_t*, size_t> data = serializer.Release();
   main_message_buf_ =
-      MallocedBuffer<char>(reinterpret_cast<char*>(data.first), data.second, env->isolate()->GetArrayBufferAllocator());
+      MallocedBuffer<char>(reinterpret_cast<char*>(data.first), data.second);
   return Just(true);
 }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -223,6 +223,10 @@ PerProcessOptionsParser::PerProcessOptionsParser() {
             "SlowBuffer instances",
             &PerProcessOptions::zero_fill_all_buffers,
             kAllowedInEnvironment);
+  AddOption("--debug-arraybuffer-allocations",
+            "", /* undocumented, only for debugging */
+            &PerProcessOptions::debug_arraybuffer_allocations,
+            kAllowedInEnvironment);
 
   AddOption("--security-reverts", "", &PerProcessOptions::security_reverts);
   AddOption("--help",

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -111,6 +111,7 @@ class PerProcessOptions {
   std::string trace_event_file_pattern = "node_trace.${rotation}.log";
   int64_t v8_thread_pool_size = 4;
   bool zero_fill_all_buffers = false;
+  bool debug_arraybuffer_allocations = false;
 
   std::vector<std::string> security_reverts;
   bool print_help = false;

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -205,10 +205,13 @@ void SerializerContext::ReleaseBuffer(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
   ASSIGN_OR_RETURN_UNWRAP(&ctx, args.Holder());
 
+  // Note: Both ValueSerializer and this Buffer::New() variant use malloc()
+  // as the underlying allocator.
   std::pair<uint8_t*, size_t> ret = ctx->serializer_.Release();
   auto buf = Buffer::New(ctx->env(),
                          reinterpret_cast<char*>(ret.first),
-                         ret.second);
+                         ret.second,
+                         true /* uses_malloc */);
 
   if (!buf.IsEmpty()) {
     args.GetReturnValue().Set(buf.ToLocalChecked());

--- a/src/stream_base-inl.h
+++ b/src/stream_base-inl.h
@@ -412,18 +412,13 @@ inline void ShutdownWrap::OnDone(int status) {
   Dispose();
 }
 
-inline void WriteWrap::SetAllocatedStorage(char* data, size_t size) {
-  CHECK_NULL(storage_);
-  storage_ = data;
-  storage_size_ = size;
-}
-
-inline char* WriteWrap::Storage() {
-  return storage_;
-}
-
 inline size_t WriteWrap::StorageSize() const {
-  return storage_size_;
+  return storage_.size();
+}
+
+inline void WriteWrap::SetAllocatedStorage(AllocatedBuffer&& storage) {
+  CHECK_NULL(storage_.data());
+  storage_ = std::move(storage);
 }
 
 inline void WriteWrap::OnDone(int status) {

--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -358,13 +358,7 @@ void StreamResource::ClearError() {
 
 
 uv_buf_t StreamListener::OnStreamAlloc(size_t suggested_size) {
-  CHECK_NE(stream_, nullptr);
-  StreamBase* stream = static_cast<StreamBase*>(stream_);
-  Environment* env = stream->stream_env();
-  auto* allocator = env->isolate()->GetArrayBufferAllocator();
-  return uv_buf_init(
-      static_cast<char*>(allocator->AllocateUninitialized(suggested_size)),
-      suggested_size);
+  return uv_buf_init(Malloc(suggested_size), suggested_size);
 }
 
 
@@ -372,19 +366,18 @@ void EmitToJSStreamListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
   CHECK_NOT_NULL(stream_);
   StreamBase* stream = static_cast<StreamBase*>(stream_);
   Environment* env = stream->stream_env();
-  auto* allocator = env->isolate()->GetArrayBufferAllocator();
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
 
   if (nread <= 0)  {
-    allocator->Free(buf.base, buf.len);
+    free(buf.base);
     if (nread < 0)
       stream->CallJSOnreadMethod(nread, Local<Object>());
     return;
   }
 
   CHECK_LE(static_cast<size_t>(nread), buf.len);
-  char* base = static_cast<char*>(allocator->Realloc(buf.base, nread));
+  char* base = Realloc(buf.base, nread);
 
   Local<Object> obj = Buffer::New(env, base, nread).ToLocalChecked();
   stream->CallJSOnreadMethod(nread, obj);

--- a/src/stream_base.h
+++ b/src/stream_base.h
@@ -74,24 +74,18 @@ class ShutdownWrap : public StreamReq {
 
 class WriteWrap : public StreamReq {
  public:
-  char* Storage();
   size_t StorageSize() const;
-  void SetAllocatedStorage(char* data, size_t size);
+  void SetAllocatedStorage(AllocatedBuffer&& storage);
 
   WriteWrap(StreamBase* stream,
             v8::Local<v8::Object> req_wrap_obj)
     : StreamReq(stream, req_wrap_obj) { }
 
-  ~WriteWrap() {
-    free(storage_);
-  }
-
   // Call stream()->EmitAfterWrite() and dispose of this request wrap.
   void OnDone(int status) override;
 
  private:
-  char* storage_ = nullptr;
-  size_t storage_size_ = 0;
+  AllocatedBuffer storage_;
 };
 
 
@@ -115,7 +109,7 @@ class StreamListener {
   // It is not valid to return a zero-length buffer from this method.
   // It is not guaranteed that the corresponding `OnStreamRead()` call
   // happens in the same event loop turn as this call.
-  virtual uv_buf_t OnStreamAlloc(size_t suggested_size);
+  virtual uv_buf_t OnStreamAlloc(size_t suggested_size) = 0;
 
   // `OnStreamRead()` is called when data is available on the socket and has
   // been read into the buffer provided by `OnStreamAlloc()`.
@@ -181,6 +175,7 @@ class ReportWritesToJSStreamListener : public StreamListener {
 // JS land via the handle’s .ondata method.
 class EmitToJSStreamListener : public ReportWritesToJSStreamListener {
  public:
+  uv_buf_t OnStreamAlloc(size_t suggested_size) override;
   void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override;
 };
 

--- a/src/stream_pipe.cc
+++ b/src/stream_pipe.cc
@@ -109,17 +109,17 @@ uv_buf_t StreamPipe::ReadableListener::OnStreamAlloc(size_t suggested_size) {
   StreamPipe* pipe = ContainerOf(&StreamPipe::readable_listener_, this);
   size_t size = std::min(suggested_size, pipe->wanted_data_);
   CHECK_GT(size, 0);
-  return uv_buf_init(Malloc(size), size);
+  return pipe->env()->AllocateManaged(size).release();
 }
 
 void StreamPipe::ReadableListener::OnStreamRead(ssize_t nread,
-                                                const uv_buf_t& buf) {
+                                                const uv_buf_t& buf_) {
   StreamPipe* pipe = ContainerOf(&StreamPipe::readable_listener_, this);
+  AllocatedBuffer buf(pipe->env(), buf_);
   AsyncScope async_scope(pipe);
   if (nread < 0) {
     // EOF or error; stop reading and pass the error to the previous listener
     // (which might end up in JS).
-    free(buf.base);
     pipe->is_eof_ = true;
     stream()->ReadStop();
     CHECK_NOT_NULL(previous_listener_);
@@ -133,19 +133,18 @@ void StreamPipe::ReadableListener::OnStreamRead(ssize_t nread,
     return;
   }
 
-  pipe->ProcessData(nread, buf);
+  pipe->ProcessData(nread, std::move(buf));
 }
 
-void StreamPipe::ProcessData(size_t nread, const uv_buf_t& buf) {
-  uv_buf_t buffer = uv_buf_init(buf.base, nread);
+void StreamPipe::ProcessData(size_t nread, AllocatedBuffer&& buf) {
+  uv_buf_t buffer = uv_buf_init(buf.data(), nread);
   StreamWriteResult res = sink()->Write(&buffer, 1);
   if (!res.async) {
-    free(buf.base);
     writable_listener_.OnStreamAfterWrite(nullptr, res.err);
   } else {
     is_writing_ = true;
     is_reading_ = false;
-    res.wrap->SetAllocatedStorage(buf.base, buf.len);
+    res.wrap->SetAllocatedStorage(std::move(buf));
     if (source() != nullptr)
       source()->ReadStop();
   }

--- a/src/stream_pipe.h
+++ b/src/stream_pipe.h
@@ -44,7 +44,7 @@ class StreamPipe : public AsyncWrap {
   // `OnStreamWantsWrite()` support.
   size_t wanted_data_ = 0;
 
-  void ProcessData(size_t nread, const uv_buf_t& buf);
+  void ProcessData(size_t nread, AllocatedBuffer&& buf);
 
   class ReadableListener : public StreamListener {
    public:

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -455,24 +455,22 @@ void UDPWrap::OnSend(uv_udp_send_t* req, int status) {
 void UDPWrap::OnAlloc(uv_handle_t* handle,
                       size_t suggested_size,
                       uv_buf_t* buf) {
-  buf->base = node::Malloc(suggested_size);
-  buf->len = suggested_size;
+  UDPWrap* wrap = static_cast<UDPWrap*>(handle->data);
+  *buf = wrap->env()->AllocateManaged(suggested_size).release();
 }
-
 
 void UDPWrap::OnRecv(uv_udp_t* handle,
                      ssize_t nread,
-                     const uv_buf_t* buf,
+                     const uv_buf_t* buf_,
                      const struct sockaddr* addr,
                      unsigned int flags) {
-  if (nread == 0 && addr == nullptr) {
-    if (buf->base != nullptr)
-      free(buf->base);
-    return;
-  }
-
   UDPWrap* wrap = static_cast<UDPWrap*>(handle->data);
   Environment* env = wrap->env();
+
+  AllocatedBuffer buf(env, *buf_);
+  if (nread == 0 && addr == nullptr) {
+    return;
+  }
 
   HandleScope handle_scope(env->isolate());
   Context::Scope context_scope(env->context());
@@ -486,14 +484,12 @@ void UDPWrap::OnRecv(uv_udp_t* handle,
   };
 
   if (nread < 0) {
-    if (buf->base != nullptr)
-      free(buf->base);
     wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);
     return;
   }
 
-  char* base = node::UncheckedRealloc(buf->base, nread);
-  argv[2] = Buffer::New(env, base, nread).ToLocalChecked();
+  buf.Resize(nread);
+  argv[2] = buf.ToBuffer().ToLocalChecked();
   argv[3] = AddressToJS(env, addr);
   wrap->MakeCallback(env->onmessage_string(), arraysize(argv), argv);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,4 +1,5 @@
 // Copyright Joyent, Inc. and other Node contributors.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the
 // "Software"), to deal in the Software without restriction, including
@@ -439,10 +440,8 @@ template <typename T>
 struct MallocedBuffer {
   T* data;
   size_t size;
-  v8::ArrayBuffer::Allocator* allocator;
 
   T* release() {
-    allocator = nullptr;
     T* ret = data;
     data = nullptr;
     return ret;
@@ -450,28 +449,18 @@ struct MallocedBuffer {
 
   inline bool is_empty() const { return data == nullptr; }
 
-  MallocedBuffer() : data(nullptr), allocator(nullptr) {}
-  MallocedBuffer(size_t size, v8::ArrayBuffer::Allocator* allocator)
-      : size(size), allocator(allocator) {
-    data = static_cast<T*>(allocator->AllocateUninitialized(size));
-  }
-  MallocedBuffer(char *data, size_t size, v8::ArrayBuffer::Allocator *allocator)
-      : data(data), size(size), allocator(allocator) {}
-  MallocedBuffer(MallocedBuffer&& other)
-      : data(other.data), size(other.size), allocator(other.allocator) {
+  MallocedBuffer() : data(nullptr) {}
+  explicit MallocedBuffer(size_t size) : data(Malloc<T>(size)), size(size) {}
+  MallocedBuffer(char* data, size_t size) : data(data), size(size) {}
+  MallocedBuffer(MallocedBuffer&& other) : data(other.data), size(other.size) {
     other.data = nullptr;
-    other.allocator = nullptr;
   }
   MallocedBuffer& operator=(MallocedBuffer&& other) {
     this->~MallocedBuffer();
     return *new(this) MallocedBuffer(std::move(other));
   }
   ~MallocedBuffer() {
-    if (allocator) {
-      allocator->Free(data, size);
-    } else {
-      free(data);
-    }
+    free(data);
   }
   MallocedBuffer(const MallocedBuffer&) = delete;
   MallocedBuffer& operator=(const MallocedBuffer&) = delete;


### PR DESCRIPTION
This PR removes our array buffer allocator patch for 10.11.0 branch and replace it with official version from https://github.com/nodejs/node/pull/26207 . The main reason being the patch isn't audited with every node version upgrade and is source of potential allocation errors https://github.com/electron/electron/search?q=set+a+breakpoint+in+malloc_error_break+to+debug&type=Issues . 

In VSCode based on electron 4.x we have been seeing these crashes https://github.com/microsoft/vscode/issues/76197.

We don't have a reliable repro for the crashes because the symbols are borked, hoping to get some data with https://github.com/electron/electron/pull/19158 in future releases. So at the moment I decided to choose the route of removing our patch for the official version as a possible solution.